### PR TITLE
feat: add support for Goodreads book ratings user statuses

### DIFF
--- a/theme/src/components/widgets/goodreads/index.js
+++ b/theme/src/components/widgets/goodreads/index.js
@@ -23,7 +23,9 @@ export default () => {
   const { profile = {}, updates = [] } = user
   const status =
     updates.length > 0
-      ? updates.find(update => update.type === 'userstatus')
+      ? updates.find(
+          update => update.type === 'userstatus' || update.type === 'review'
+        )
       : {}
 
   return (

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -14,6 +14,7 @@ const getRatingStars = count => {
     Array(n)
       .fill(char)
       .join('')
+
   const rating = repeat('★', count) + repeat('☆', 5 - count)
 
   return rating

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -9,14 +9,42 @@ import ViewExternal from '../view-external'
 
 const stripHtmlElements = text => text.replace(/<[^>]+>/g, '')
 
+const getRatingStars = count => {
+  const repeat = (char, n) =>
+    Array(n)
+      .fill(char)
+      .join('')
+  const rating = repeat('★', count) + repeat('☆', 5 - count)
+
+  return rating
+}
+
+const mapStatusToTemplate = {
+  review: ({ book, rating }) =>
+    `rated ${book.title} ${rating} out of 5 stars: ${getRatingStars(rating)}.`,
+  userstatus: ({ actionText }) => `${stripHtmlElements(actionText)}`
+}
+
 const UserStatus = ({ isLoading, status, actorName }) => {
   if (isLoading) {
     return 'Loading...'
   }
 
-  const { actionText, updated, link } = status
+  const { link, type, updated } = status
 
-  const statusText = actionText && stripHtmlElements(actionText)
+  console.log('Mapping text for status...', {
+    status
+  })
+
+  // const statusText = actionText && stripHtmlElements(actionText)
+  const statusText = mapStatusToTemplate[type]
+    ? mapStatusToTemplate[type](status)
+    : 'Loading...'
+
+  console.log({
+    updated,
+    parsed: new Date(updated)
+  })
 
   return (
     <Box>

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -22,7 +22,7 @@ const getRatingStars = count => {
 const mapStatusToTemplate = {
   review: ({ book, rating }) =>
     `rated ${book.title} ${rating} out of 5 stars: ${getRatingStars(rating)}.`,
-  userstatus: ({ actionText }) => `${stripHtmlElements(actionText)}`
+  userstatus: ({ actionText }) => stripHtmlElements(actionText)
 }
 
 const UserStatus = ({ isLoading, status, actorName }) => {
@@ -32,19 +32,9 @@ const UserStatus = ({ isLoading, status, actorName }) => {
 
   const { link, type, updated } = status
 
-  console.log('Mapping text for status...', {
-    status
-  })
-
-  // const statusText = actionText && stripHtmlElements(actionText)
   const statusText = mapStatusToTemplate[type]
     ? mapStatusToTemplate[type](status)
     : 'Loading...'
-
-  console.log({
-    updated,
-    parsed: new Date(updated)
-  })
 
   return (
     <Box>
@@ -84,9 +74,9 @@ const UserStatus = ({ isLoading, status, actorName }) => {
 UserStatus.propTypes = {
   /** The name of the person the status is about. */
   actorName: PropTypes.string,
-  /** Sets the component in a loading state when true. */
+  /** Widget is in a loading state if true. */
   isLoading: PropTypes.bool,
-  /** The pull request on GitHub. */
+  /** The Goodreads user status object. */
   status: PropTypes.shape({
     actionText: PropTypes.string,
     updated: PropTypes.string,


### PR DESCRIPTION
This PR updates the Goodreads user status widget to include user statuses with book ratings. These user statuses are created when a book is finished and given a star rating. Before this PR, a book could show up in the recently read list while also simultaneously showcasing a progress status message created pages before the book was finished.

### Screenshot

Rating status is filtered out.

![Screenshot_2020-01-15 CHRISVOGT me](https://user-images.githubusercontent.com/1934719/72502517-5a014c00-37ee-11ea-950e-8d70de11fb1d.png)

Rating status is included, shown in new template.

![Screenshot_2020-01-15 Private Sphere](https://user-images.githubusercontent.com/1934719/72502535-6a192b80-37ee-11ea-926b-55032bdd9fb1.png)
