### PR TITLE
design: lighten widget design and rename blog to latest content

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "A personal blog with built-in social widgets for bloggers, creatives, and developers.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -18,7 +18,8 @@ const Header = ({
     sx={{
       variant: `styles.Header`,
       background: hideBackground ? '' : `url(${trianglify})`,
-      backgroundSize: `cover`
+      backgroundSize: `cover`,
+      backgroundPosition: `bottom center`
     }}
   >
     <div

--- a/theme/src/components/widgets/call-to-action.js
+++ b/theme/src/components/widgets/call-to-action.js
@@ -13,7 +13,7 @@ const CallToAction = ({ children, title, to, url }) => {
   return (
     <p
       sx={{
-        marginBottom: `1rem`,
+        marginBottom: [``, `1rem`],
         marginTop: 4,
         variant: `styles.WidgetFooter`
       }}

--- a/theme/src/components/widgets/call-to-action.js
+++ b/theme/src/components/widgets/call-to-action.js
@@ -11,7 +11,13 @@ const CallToAction = ({ children, title, to, url }) => {
       }
     : {}
   return (
-    <p sx={{ marginTop: 4, variant: `styles.WidgetFooter` }}>
+    <p
+      sx={{
+        marginBottom: `1rem`,
+        marginTop: 4,
+        variant: `styles.WidgetFooter`
+      }}
+    >
       <Styled.a
         href={url}
         sx={{ fontFamily: `heading`, fontSize: 3 }}

--- a/theme/src/components/widgets/github/pinned-items.js
+++ b/theme/src/components/widgets/github/pinned-items.js
@@ -24,7 +24,7 @@ const PinnedItems = ({ isLoading, pinnedItems }) => {
           display: 'grid',
           gridAutoRows: '1fr',
           gridGap: '1rem',
-          gridTemplateColumns: ['', '', 'repeat(2, 1fr)']
+          gridTemplateColumns: ['', '', '', 'repeat(2, 1fr)']
         }}
       >
         {items.map((item, index) => (

--- a/theme/src/components/widgets/github/renderers/repository.js
+++ b/theme/src/components/widgets/github/renderers/repository.js
@@ -37,18 +37,17 @@ const Repository = ({
             sx={{
               backgroundColor: `colors.background`,
               border: `2px solid white`,
-              borderRadius: `4px`,
-              mr: 2
+              borderRadius: `4px`
             }}
             width='42'
           />
         </LazyLoad>
       </Flex>
-      <Flex sx={{ flexDirection: `column`, alignSelf: `center` }}>
+      <Flex sx={{ flexDirection: `column`, alignSelf: `center`, pl: 3 }}>
         <Heading as='h5' sx={{ p: 0, mb: 0 }}>
           {nameWithOwner}
         </Heading>
-        <span sx={{ fontSize: `small`, p: 0 }}>
+        <span sx={{ color: `textMuted`, fontSize: `small`, p: 0 }}>
           Updated {ago(new Date(updatedAt))}
         </span>
       </Flex>

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -11,9 +11,7 @@ export default ({ banner, date, excerpt, link, title }) => (
     <Styled.h4 sx={{ mt: 1 }}>{title}</Styled.h4>
 
     <div sx={{ display: `flex`, flexGrow: 1, mt: 0, mb: 1 }}>
-      <span>
-        {excerpt} <em>Read more &rarr;</em>
-      </span>
+      <span>{excerpt}</span>
 
       {banner && (
         <img
@@ -22,6 +20,11 @@ export default ({ banner, date, excerpt, link, title }) => (
           sx={{ borderRadius: `4px`, ml: 2 }}
         />
       )}
+    </div>
+
+    <div>
+      Read more
+      <span className='read-more-icon'>&rarr;</span>
     </div>
   </Link>
 )

--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.js
@@ -26,7 +26,9 @@ export default () => {
   }
   return (
     <Widget id='posts'>
-      <Heading sx={{ variant: `styles.WidgetHeadline` }}>Blog</Heading>
+      <Heading sx={{ variant: `styles.WidgetHeadline` }}>
+        Recently Published
+      </Heading>
       <div sx={{ width: `100%` }}>
         <Grid
           sx={{
@@ -53,8 +55,8 @@ export default () => {
           ))}
         </Grid>
       </div>
-      <CallToAction title='View all blog posts' to='/blog'>
-        Blog posts &rarr;
+      <CallToAction title='View all latest content' to='/latest'>
+        More posts &rarr;
       </CallToAction>
     </Widget>
   )

--- a/theme/src/data/navigation.json
+++ b/theme/src/data/navigation.json
@@ -4,10 +4,10 @@
     "header": {
       "left": [
         {
-          "path": "/blog",
-          "slug": "blog",
-          "text": "Blog",
-          "title": "Blog"
+          "path": "/latest",
+          "slug": "latest",
+          "text": "Latest",
+          "title": "Latest content"
         }
       ],
       "right": [

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -110,7 +110,7 @@ export default {
   },
   MetricCard: {
     ...card,
-    borderLeftColor: `textMuted`,
+    borderLeftColor: `text`,
     span: {
       fontFamily: `heading`,
       fontWeight: `bold`,
@@ -148,13 +148,11 @@ export default {
   },
   Widget: {
     backgroundColor: `background`,
-    borderLeftWidth: [``, `3px`],
-    borderLeftStyle: [`none`, `solid`],
-    borderLeftColor: [``, `#9231A7`],
     borderRadius: [``, `3px`],
     borderTop: [``, `1px solid #efefef`],
     borderRight: [``, `1px solid #efefef`],
     borderBottom: [`2px solid #f9f9f9`, `1px solid #eaeaea`],
+    borderLeft: [``, `1px solid #efefef`],
     mb: [3, 4],
     px: [0, 3, 4],
     py: [0, 3],

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -92,7 +92,17 @@ export default {
     ...floatOnHover,
     ...card,
     display: `flex`,
-    flexDirection: `column`
+    flexDirection: `column`,
+    '.read-more-icon': {
+      display: `inline`,
+      transition: `all .3s ease-in-out`,
+      opacity: 0,
+      paddingLeft: 0
+    },
+    '&:hover .read-more-icon': {
+      opacity: 1,
+      paddingLeft: `8px`
+    }
   },
   RepositoryCard: {
     ...floatOnHover,
@@ -142,13 +152,14 @@ export default {
     borderLeftStyle: [`none`, `solid`],
     borderLeftColor: [``, `#9231A7`],
     borderRadius: [``, `3px`],
-    borderTop: [``, `1px solid white`],
-    boxShadow: [``, themePreset.shadows.default],
+    borderTop: [``, `1px solid #efefef`],
+    borderRight: [``, `1px solid #efefef`],
+    borderBottom: [`2px solid #f9f9f9`, `1px solid #eaeaea`],
     mb: [3, 4],
     px: [0, 3, 4],
     py: [0, 3],
-    '&:not(:last-of-type)': {
-      borderBottom: [`2px solid #f9f9f9`, `1px solid white`]
+    '&:last-of-type': {
+      borderBottom: [`none`, `1px solid #eaeaea`]
     }
   },
   WidgetHeadline: {

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -55,6 +55,8 @@ export default {
   },
   footer: {
     background: `url(${trianglify})`,
+    backgroundSize: `cover`,
+    backgroundPosition: `top center`,
     color: `light`,
     a: {
       color: `white`
@@ -81,8 +83,6 @@ export default {
   Header: {
     alignItems: `center`,
     backgroundColor: `secondary`,
-    backgroundPosition: `top`,
-    backgroundSize: `cover`,
     color: `white`,
     display: `block`,
     transition: `all 0.3s ease-in-out`,

--- a/theme/src/pages/latest.jsx
+++ b/theme/src/pages/latest.jsx
@@ -15,8 +15,8 @@ export default ({ data }) => {
   return (
     <Layout>
       <SEO
-        title='Recent Blog Posts'
-        description='An overview of recent articles posted to my blog'
+        title='Latest Content and Blog Posts'
+        description='A list of the most recent content posted to my website'
       />
 
       <Flex
@@ -28,7 +28,7 @@ export default ({ data }) => {
         }}
       >
         <Container sx={{ flexGrow: 1 }}>
-          <h1>Blog Posts</h1>
+          <h1>Latest Content</h1>
           <Styled.div
             sx={{
               display: `grid`,


### PR DESCRIPTION
Updates to the UI, and renames the "blog" page to "latest content".

### ❯ Comparison

| Before 	| After 	|
|--------	|-------	|
| ![Screenshot: Before](https://user-images.githubusercontent.com/1934719/79084611-8d6a4e80-7ce9-11ea-89a9-55513ab722c4.png) | ![Screenshot: After](https://user-images.githubusercontent.com/1934719/79084624-9ce99780-7ce9-11ea-80fa-c28307e918fb.png) |
| NA | ![Demonstration: After](https://user-images.githubusercontent.com/1934719/79084645-b38fee80-7ce9-11ea-97ab-dad740e3f7c6.gif) |
