### PR TITLE
design: remove backgrounds and borders from all widgets

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "A personal blog with built-in social widgets for bloggers, creatives, and developers.",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -6,7 +6,7 @@ export const themePreset = tailwind
 
 const floatOnHover = {
   transform: `scale(1.015)`,
-  transition: `all .3s ease-in-out`,
+  transition: `all .25s ease-in-out`,
 
   '&:hover, &:focus': {
     boxShadow: `lg`
@@ -156,18 +156,8 @@ export default {
     height: `100%`
   },
   Widget: {
-    backgroundColor: `background`,
-    borderRadius: [``, `3px`],
-    borderTop: [``, `1px solid #efefef`],
-    borderRight: [``, `1px solid #efefef`],
-    borderBottom: [`2px solid #f9f9f9`, `1px solid #eaeaea`],
-    borderLeft: [``, `1px solid #efefef`],
     mb: [3, 4],
-    px: [0, 3, 4],
-    py: [0, 3, 4],
-    '&:last-of-type': {
-      borderBottom: [`none`, `1px solid #eaeaea`]
-    }
+    py: [0, 3, 4]
   },
   WidgetHeadline: {
     textAlign: [`center`, `left`],

--- a/theme/src/pages/latest.jsx
+++ b/theme/src/pages/latest.jsx
@@ -28,14 +28,15 @@ export default ({ data }) => {
         }}
       >
         <Container sx={{ flexGrow: 1 }}>
-          <h1>Latest Content</h1>
+          <Styled.h1>Blog</Styled.h1>
 
           <Styled.div
             sx={{
               display: `grid`,
               gridAutoRows: `1fr`,
               gridGap: 4,
-              gridTemplateColumns: [``, ``, `repeat(2, 1fr)`]
+              gridTemplateColumns: [``, ``, `repeat(2, 1fr)`],
+              mt: 4
             }}
           >
             {posts.map(post => (

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -75,7 +75,7 @@ const HomeTemplate = props => {
         sx={{
           backgroundColor: `colors.background`,
           minHeight: `500px`,
-          pt: 4
+          pt: 3
         }}
       >
         <Container>


### PR DESCRIPTION
This PR removes all hard borders around the home page widgets.

| Before 	| After 	|
|--------	|-------	|
| ![Before](https://user-images.githubusercontent.com/1934719/81081220-7fea5380-8ea6-11ea-8bd9-13f6856d05e5.png) | ![After](https://user-images.githubusercontent.com/1934719/81081233-837dda80-8ea6-11ea-9128-55f63ffe7378.png) |
