### PR TITLE
fix: connect the remaining widget loaders

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "A personal blog with built-in social widgets for bloggers, creatives, and developers.",
-  "version": "0.9.4",
+  "version": "0.9.5-alpha",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/github/github-widget.js
+++ b/theme/src/components/widgets/github/github-widget.js
@@ -36,6 +36,7 @@ const GitHubWidget = () => {
     <CallToAction
       title={`${githubUsername} on GitHub`}
       url={`https://www.github.com/${githubUsername}`}
+      isLoading={isLoading}
     >
       View profile
       <span className='read-more-icon'>&rarr;</span>

--- a/theme/src/components/widgets/goodreads/goodreads-widget.js
+++ b/theme/src/components/widgets/goodreads/goodreads-widget.js
@@ -33,6 +33,7 @@ export default () => {
     <CallToAction
       title={`${goodreadsUsername} on Goodreads`}
       url={`https://www.goodreads.com/${goodreadsUsername}`}
+      isLoading={isLoadingBooks || isLoadingUser}
     >
       View profile
       <span className='read-more-icon'>&rarr;</span>

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -31,6 +31,7 @@ export default () => {
     <CallToAction
       title={`${instagramUsername} on Instagram`}
       url={`https://www.instagram.com/${instagramUsername}`}
+      isLoading={isLoading}
     >
       View profile
       <span className='read-more-icon'>&rarr;</span>


### PR DESCRIPTION
Last night, when implementing the rest of the skeleton loaders, I missed three of the spinners that indicate the overall loading state of the widgets. This PR connects those.

| ![skeleton--before](https://user-images.githubusercontent.com/1934719/81710048-44600400-9427-11ea-8bcb-6ec6139514fb.png) | ![skeleton--after](https://user-images.githubusercontent.com/1934719/81710067-4924b800-9427-11ea-8e98-c946cb8cfba6.png) |