### PR TITLE
chore: add unit tests for API request modules

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.10.1-alpha.2",
+  "version": "0.10.1-alpha.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/api/personal-api/get-instagram.posts.spec.js
+++ b/theme/src/api/personal-api/get-instagram.posts.spec.js
@@ -1,0 +1,30 @@
+import axios from 'axios'
+
+import getInstagramPosts from './get-instagram-posts'
+import instagramFixture from '../../../__mocks__/instagram.mock.json'
+
+const mockAxiosResponse = {
+  data: instagramFixture
+}
+
+jest.mock('axios')
+
+describe('getInstagramPosts', () => {
+  it('defaults to an empty array on successful response with no posts', async () => {
+    axios.mockImplementationOnce(() => Promise.resolve({}))
+    await expect(getInstagramPosts()).resolves.toEqual([])
+  })
+
+  it('fetches, selects, and returns expected data from the expected API endpoint', async () => {
+    axios.mockImplementationOnce(() => Promise.resolve(mockAxiosResponse))
+    await expect(getInstagramPosts()).resolves.toEqual(
+      instagramFixture.result.photos
+    )
+  })
+
+  it('serializes errors for rejected requests', async () => {
+    const errorMessage = 'Something went wrong!'
+    axios.mockImplementationOnce(() => Promise.reject(errorMessage))
+    await expect(getInstagramPosts()).resolves.toEqual({ error: errorMessage })
+  })
+})

--- a/theme/src/api/personal-api/get-recent-books.spec.js
+++ b/theme/src/api/personal-api/get-recent-books.spec.js
@@ -1,0 +1,28 @@
+import axios from 'axios'
+
+import getRecentBooks from './get-recent-books'
+import recentlyReadBooksFixture from '../../../__mocks__/instagram.mock.json'
+
+const mockAxiosResponse = {
+  data: recentlyReadBooksFixture
+}
+
+jest.mock('axios')
+
+describe('getRecentBooks', () => {
+  it('defaults to an empty array on successful response with no books', async () => {
+    axios.mockImplementationOnce(() => Promise.resolve({}))
+    await expect(getRecentBooks()).resolves.toEqual([])
+  })
+
+  it('fetches, selects, and returns expected data from the expected API endpoint', async () => {
+    axios.mockImplementationOnce(() => Promise.resolve(mockAxiosResponse))
+    await expect(getRecentBooks()).resolves.toEqual(recentlyReadBooksFixture)
+  })
+
+  it('serializes errors for rejected requests', async () => {
+    const errorMessage = 'Something went wrong!'
+    axios.mockImplementationOnce(() => Promise.reject(errorMessage))
+    await expect(getRecentBooks()).resolves.toEqual({ error: errorMessage })
+  })
+})

--- a/theme/src/api/personal-api/get-social-profiles.js
+++ b/theme/src/api/personal-api/get-social-profiles.js
@@ -4,6 +4,11 @@ const getProfiles = response => {
   const [profilesResponse, metaResponse] = response
   const { data: { result: { profiles = [] } = {} } = {} } = profilesResponse
   const { data: { result: { metas = [] } = {} } = {} } = metaResponse
+
+  if (!metas.length) {
+    return profiles.filter(Boolean)
+  }
+
   const order = metas.find(meta => meta.key === 'socialProfilesOrder').order
   const sortedProfiles = order
     .map((meta, index) => profiles[index])

--- a/theme/src/api/personal-api/get-social-profiles.spec.js
+++ b/theme/src/api/personal-api/get-social-profiles.spec.js
@@ -1,0 +1,38 @@
+import axios from 'axios'
+
+import getSocialProfiles from './get-social-profiles'
+
+import metasFixture from '../../../__mocks__/metas.mock.json'
+import socialProfilesFixture from '../../../__mocks__/profiles.mock.json'
+
+const mockProfilesAxiosResponse = {
+  data: socialProfilesFixture
+}
+
+const mockMetasresponse = {
+  data: metasFixture
+}
+
+jest.mock('axios')
+
+describe('getRecentBooks', () => {
+  it('defaults to an empty array on successful response with no data', async () => {
+    axios
+      .mockImplementationOnce(() => Promise.resolve({}))
+      .mockImplementationOnce(() => Promise.resolve({}))
+      
+    await expect(getSocialProfiles()).resolves.toEqual([])
+  })
+
+  // NOTE(cvogt): when doing this, also look into factoring out the sorting logic
+  // from the API request module
+  test.todo('it fetches, selects, and returns expected data from the expected API endpoin')
+
+  it('serializes errors for rejected requests', async () => {
+    const errorMessage = 'Something went wrong!'
+    axios
+      .mockImplementationOnce(() => Promise.reject(errorMessage))
+      .mockImplementationOnce(() => Promise.reject(errorMessage))
+    await expect(getSocialProfiles()).resolves.toEqual({ error: errorMessage })
+  })
+})


### PR DESCRIPTION
This PR adds more unit tests, specifically for the modules that request data from APIs.