### PR TITLE
feat: add a custom media post template

### DIFF
--- a/example/content/posts/2020-02-10--lorum-2.mdx
+++ b/example/content/posts/2020-02-10--lorum-2.mdx
@@ -8,7 +8,7 @@ description: >
 excerpt: >
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 keywords: ['react']
-banner: 'https://picsum.photos/560/448?sig=2'
+banner: 'https://picsum.photos/560/448?sig=5'
 ---
 
 Orci dapibus ultrices in iaculis nunc sed augue. Tellus elementum sagittis vitae et leo. Lacinia quis vel eros donec ac odio tempor. Massa tempor nec feugiat nisl. Augue mauris augue neque gravida. Tellus elementum sagittis vitae et leo duis ut diam quam. In egestas erat imperdiet sed euismod nisi. Erat pellentesque adipiscing commodo elit at imperdiet dui. Turpis nunc eget lorem dolor sed viverra ipsum nunc. Amet venenatis urna cursus eget nunc scelerisque. Eget duis at tellus at urna condimentum mattis. Nec feugiat in fermentum posuere urna nec. Sed lectus vestibulum mattis ullamcorper velit sed. Mauris sit amet massa vitae tortor condimentum. Lorem sed risus ultricies tristique nulla aliquet enim tortor at. Massa eget egestas purus viverra accumsan. Ligula ullamcorper malesuada proin libero nunc. A scelerisque purus semper eget duis. Varius vel pharetra vel turpis nunc eget lorem dolor.

--- a/example/content/posts/2020-09-08--audio.mdx
+++ b/example/content/posts/2020-09-08--audio.mdx
@@ -1,0 +1,20 @@
+---
+slug: /types/sound
+date: '2020-02-10T09:00:00.000Z'
+title: Music post demo
+category: songs
+description: >
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+excerpt: >
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+keywords: ['react']
+banner: 'https://picsum.photos/560/448?sig=7'
+soundcloudId: 880888540
+type: media
+---
+
+Orci dapibus ultrices in iaculis nunc sed augue. Tellus elementum sagittis vitae et leo. Lacinia quis vel eros donec ac odio tempor. Massa tempor nec feugiat nisl. Augue mauris augue neque gravida. Tellus elementum sagittis vitae et leo duis ut diam quam. In egestas erat imperdiet sed euismod nisi. Erat pellentesque adipiscing commodo elit at imperdiet dui. Turpis nunc eget lorem dolor sed viverra ipsum nunc. Amet venenatis urna cursus eget nunc scelerisque. Eget duis at tellus at urna condimentum mattis. Nec feugiat in fermentum posuere urna nec. Sed lectus vestibulum mattis ullamcorper velit sed. Mauris sit amet massa vitae tortor condimentum. Lorem sed risus ultricies tristique nulla aliquet enim tortor at. Massa eget egestas purus viverra accumsan. Ligula ullamcorper malesuada proin libero nunc. A scelerisque purus semper eget duis. Varius vel pharetra vel turpis nunc eget lorem dolor.
+
+Cras ornare arcu dui vivamus arcu felis bibendum ut tristique. Id nibh tortor id aliquet lectus proin nibh. Est ullamcorper eget nulla facilisi etiam dignissim. Aliquam id diam maecenas ultricies mi eget mauris. Condimentum vitae sapien pellentesque habitant morbi. Egestas erat imperdiet sed euismod nisi porta lorem. Pulvinar elementum integer enim neque. Nulla aliquet porttitor lacus luctus accumsan. At quis risus sed vulputate. Ac placerat vestibulum lectus mauris ultrices. Donec et odio pellentesque diam volutpat commodo sed egestas egestas. Faucibus purus in massa tempor nec feugiat. Arcu dui vivamus arcu felis bibendum ut. Porttitor eget dolor morbi non arcu. Tellus orci ac auctor augue mauris augue. Nec dui nunc mattis enim ut tellus. Integer eget aliquet nibh praesent tristique.
+
+Facilisis magna etiam tempor orci eu lobortis elementum. Massa ultricies mi quis hendrerit dolor. Risus commodo viverra maecenas accumsan lacus vel facilisis volutpat est. Sem et tortor consequat id porta nibh venenatis cras. Lacinia at quis risus sed vulputate odio ut enim blandit. Aliquam etiam erat velit scelerisque in dictum. Amet nisl purus in mollis nunc sed id semper risus. Massa sed elementum tempus egestas sed. Commodo viverra maecenas accumsan lacus vel. Congue eu consequat ac felis donec et odio pellentesque. Porta nibh venenatis cras sed felis eget velit aliquet sagittis. Neque gravida in fermentum et sollicitudin ac orci. Ut tellus elementum sagittis vitae et leo. Ultrices dui sapien eget mi proin sed libero enim sed.

--- a/example/content/posts/2020-09-08--video.mdx
+++ b/example/content/posts/2020-09-08--video.mdx
@@ -1,0 +1,20 @@
+---
+slug: /types/video
+date: '2020-02-10T09:00:00.000Z'
+title: Video post demo
+category: videos
+description: >
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+excerpt: >
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+keywords: ['react']
+banner: 'https://picsum.photos/560/448?sig=3'
+youtubeSrc: https://www.youtube.com/embed/XJashBvI17A
+type: media
+---
+
+Orci dapibus ultrices in iaculis nunc sed augue. Tellus elementum sagittis vitae et leo. Lacinia quis vel eros donec ac odio tempor. Massa tempor nec feugiat nisl. Augue mauris augue neque gravida. Tellus elementum sagittis vitae et leo duis ut diam quam. In egestas erat imperdiet sed euismod nisi. Erat pellentesque adipiscing commodo elit at imperdiet dui. Turpis nunc eget lorem dolor sed viverra ipsum nunc. Amet venenatis urna cursus eget nunc scelerisque. Eget duis at tellus at urna condimentum mattis. Nec feugiat in fermentum posuere urna nec. Sed lectus vestibulum mattis ullamcorper velit sed. Mauris sit amet massa vitae tortor condimentum. Lorem sed risus ultricies tristique nulla aliquet enim tortor at. Massa eget egestas purus viverra accumsan. Ligula ullamcorper malesuada proin libero nunc. A scelerisque purus semper eget duis. Varius vel pharetra vel turpis nunc eget lorem dolor.
+
+Cras ornare arcu dui vivamus arcu felis bibendum ut tristique. Id nibh tortor id aliquet lectus proin nibh. Est ullamcorper eget nulla facilisi etiam dignissim. Aliquam id diam maecenas ultricies mi eget mauris. Condimentum vitae sapien pellentesque habitant morbi. Egestas erat imperdiet sed euismod nisi porta lorem. Pulvinar elementum integer enim neque. Nulla aliquet porttitor lacus luctus accumsan. At quis risus sed vulputate. Ac placerat vestibulum lectus mauris ultrices. Donec et odio pellentesque diam volutpat commodo sed egestas egestas. Faucibus purus in massa tempor nec feugiat. Arcu dui vivamus arcu felis bibendum ut. Porttitor eget dolor morbi non arcu. Tellus orci ac auctor augue mauris augue. Nec dui nunc mattis enim ut tellus. Integer eget aliquet nibh praesent tristique.
+
+Facilisis magna etiam tempor orci eu lobortis elementum. Massa ultricies mi quis hendrerit dolor. Risus commodo viverra maecenas accumsan lacus vel facilisis volutpat est. Sem et tortor consequat id porta nibh venenatis cras. Lacinia at quis risus sed vulputate odio ut enim blandit. Aliquam etiam erat velit scelerisque in dictum. Amet nisl purus in mollis nunc sed id semper risus. Massa sed elementum tempus egestas sed. Commodo viverra maecenas accumsan lacus vel. Congue eu consequat ac felis donec et odio pellentesque. Porta nibh venenatis cras sed felis eget velit aliquet sagittis. Neque gravida in fermentum et sollicitudin ac orci. Ut tellus elementum sagittis vitae et leo. Ultrices dui sapien eget mi proin sed libero enim sed.

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -15,6 +15,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
               fields {
                 id
                 slug
+                type
               }
             }
           }
@@ -22,14 +23,19 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
       }
     `
   )
+
   if (result.errors) {
     reporter.panic('error loading content', result.errors)
     return
   }
+
   result.data.allMdx.edges.forEach(({ node }) => {
     actions.createPage({
       path: node.fields.slug ? node.fields.slug : '/',
-      component: require.resolve('./src/templates/post'),
+      component:
+        node.fields.type === 'media'
+          ? require.resolve('./src/templates/media')
+          : require.resolve('./src/templates/post'),
       context: {
         id: node.fields.id
       }
@@ -66,6 +72,15 @@ exports.onCreateNode = ({ node, getNode, actions, reporter }) => {
         name: `category`,
         node,
         value: category
+      })
+    }
+
+    const type = node.frontmatter.type
+    if (type) {
+      createNodeField({
+        name: `type`,
+        node,
+        value: type
       })
     }
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -207,20 +207,17 @@ export default {
   },
 
   VideoWrapper: {
-    background: `blue`,
-    border: `3px solid red`,
     position: `relative`,
     paddingBottom: `56.25%` /* 16:9 */,
     paddingTop: `25px`,
-    height: 0
-  },
-
-  'videoWrapper iframe': {
-    position: `absolute`,
-    top: 0,
-    left: 0,
-    width: `100%`,
-    height: `100%`
+    height: 0,
+    iframe: {
+      position: `absolute`,
+      top: 0,
+      left: 0,
+      width: `100%`,
+      height: `100%`
+    }
   },
 
   Widget: {
@@ -289,21 +286,6 @@ export default {
 
   '.text-center': {
     textAlign: `center`
-  },
-
-  '.VideoWrapper': {
-    position: `relative`,
-    paddingBottom: `56.25%` /* 16:9 */,
-    paddingTop: `25px`,
-    height: 0
-  },
-
-  '.VideoWrapper iframe': {
-    position: `absolute`,
-    top: 0,
-    left: 0,
-    width: `100%`,
-    height: `100%`
   },
 
   '.gatsby-highlight pre[class*="language-"]': {

--- a/theme/src/shortcodes/__snapshots__/soundcloud.spec.js.snap
+++ b/theme/src/shortcodes/__snapshots__/soundcloud.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SoundCloud Shortcode matches the snapshot 1`] = `
+<iframe
+  allow="autoplay"
+  frameborder="no"
+  height="166"
+  scrolling="no"
+  src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/880888540&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+  title="Song on SoundCloud"
+  width="100%"
+/>
+`;

--- a/theme/src/shortcodes/__snapshots__/youtube.spec.js.snap
+++ b/theme/src/shortcodes/__snapshots__/youtube.spec.js.snap
@@ -2,11 +2,12 @@
 
 exports[`YouTube Shortcode matches the snapshot 1`] = `
 <div
-  className="VideoWrapper css-0"
+  className="css-d7h4os-YouTube"
 >
   <iframe
     allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen={true}
+    className="VideoFrame"
     frameBorder="0"
     height="315"
     src="https://www.youtube-nocookie.com/embed/XJashBvI17A"

--- a/theme/src/shortcodes/soundcloud.js
+++ b/theme/src/shortcodes/soundcloud.js
@@ -1,0 +1,18 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
+const buildSoundCloudEmbedURL = trackId =>
+  `https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/${trackId}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true`
+
+const SoundCloud = ({ soundcloudId }) => (
+  <iframe
+    width='100%'
+    height='166'
+    scrolling='no'
+    frameborder='no'
+    allow='autoplay'
+    src={buildSoundCloudEmbedURL(soundcloudId)}
+  ></iframe>
+)
+
+export default SoundCloud

--- a/theme/src/shortcodes/soundcloud.js
+++ b/theme/src/shortcodes/soundcloud.js
@@ -4,14 +4,15 @@ import { jsx } from 'theme-ui'
 const buildSoundCloudEmbedURL = trackId =>
   `https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/${trackId}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true`
 
-const SoundCloud = ({ soundcloudId }) => (
+const SoundCloud = ({ title, soundcloudId }) => (
   <iframe
-    width='100%'
+    allow='autoplay'
+    frameborder='no'
     height='166'
     scrolling='no'
-    frameborder='no'
-    allow='autoplay'
     src={buildSoundCloudEmbedURL(soundcloudId)}
+    title={title || 'Song on SoundCloud'}
+    width='100%'
   ></iframe>
 )
 

--- a/theme/src/shortcodes/soundcloud.spec.js
+++ b/theme/src/shortcodes/soundcloud.spec.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import SoundCloud from './soundcloud'
+
+describe('SoundCloud Shortcode', () => {
+  it('matches the snapshot', () => {
+    const tree = renderer
+      .create(<SoundCloud soundcloudId='880888540' />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a default title if one is not provided', () => {
+    const testRenderer = renderer.create(
+      <SoundCloud soundcloudId='880888540' />
+    )
+    const testInstance = testRenderer.root
+    expect(testInstance.findByType('iframe').props.title).toEqual(
+      'Song on SoundCloud'
+    )
+  })
+})

--- a/theme/src/shortcodes/youtube.js
+++ b/theme/src/shortcodes/youtube.js
@@ -4,14 +4,14 @@ import { jsx, Styled } from 'theme-ui'
 const YouTube = ({ title, url }) => (
   <Styled.div sx={{ variant: `styles.VideoWrapper` }}>
     <iframe
-      className='VideoFrame'
-      title={title || 'YouTube video'}
-      width='560'
-      height='315'
-      src={url}
-      frameBorder='0'
       allow='accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'
       allowFullScreen
+      className='VideoFrame'
+      frameBorder='0'
+      height='315'
+      src={url}
+      title={title || 'Video on YouTube'}
+      width='560'
     ></iframe>
   </Styled.div>
 )

--- a/theme/src/shortcodes/youtube.js
+++ b/theme/src/shortcodes/youtube.js
@@ -2,8 +2,9 @@
 import { jsx, Styled } from 'theme-ui'
 
 const YouTube = ({ title, url }) => (
-  <Styled.div className='VideoWrapper'>
+  <Styled.div sx={{ variant: `styles.VideoWrapper` }}>
     <iframe
+      className='VideoFrame'
       title={title || 'YouTube video'}
       width='560'
       height='315'

--- a/theme/src/shortcodes/youtube.spec.js
+++ b/theme/src/shortcodes/youtube.spec.js
@@ -20,6 +20,8 @@ describe('YouTube Shortcode', () => {
       <YouTube url='https://www.youtube-nocookie.com/embed/XJashBvI17A' />
     )
     const testInstance = testRenderer.root
-    expect(testInstance.findByType('iframe').props.title).toEqual('YouTube video')
+    expect(testInstance.findByType('iframe').props.title).toEqual(
+      'Video on YouTube'
+    )
   })
 })

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -1,0 +1,108 @@
+/** @jsx jsx */
+import { Container, Flex, jsx, Styled, useThemeUI } from 'theme-ui'
+import { graphql } from 'gatsby'
+import { Heading } from '@theme-ui/components'
+import { MDXRenderer } from 'gatsby-plugin-mdx'
+import PropTypes from 'prop-types'
+
+import isDarkMode from '../helpers/isDarkMode'
+
+import Footer from '../components/footer'
+import Layout from '../components/layout'
+import SEO from '../components/seo'
+
+import SoundCloud from '../shortcodes/soundcloud'
+import YouTube from '../shortcodes/youtube'
+
+const MediaTemplate = ({ data }) => {
+  const { colorMode } = useThemeUI()
+  const { mdx } = data
+
+  const banner = mdx.frontmatter.banner
+  const category = mdx.fields.category
+  const date = mdx.frontmatter.date
+  const description = mdx.frontmatter.description
+  const title = mdx.frontmatter.title
+
+  const youtubeSrc = mdx.frontmatter.youtubeSrc
+  const soundcloudId = mdx.frontmatter.soundcloudId
+
+  return (
+    <Layout>
+      <SEO
+        article={true}
+        description={description}
+        image={banner}
+        title={title}
+      />
+
+      {(youtubeSrc || soundcloudId) && (
+        <div
+          sx={{
+            backgroundColor: theme =>
+              isDarkMode(colorMode)
+                ? theme.colors.gray[9]
+                : theme.colors.gray[4],
+            textAlign: `center`,
+            paddingY: 3
+          }}
+        >
+          <Container>
+            {youtubeSrc && <YouTube url={youtubeSrc} />}
+            {soundcloudId && <SoundCloud soundcloudId={soundcloudId} />}
+          </Container>
+        </div>
+      )}
+
+      <Flex
+        sx={{
+          flexDirection: `column`,
+          flexGrow: 1,
+          py: 3
+        }}
+      >
+        <Container sx={{ height: `100%` }}>
+          {category && <div sx={{ variant: `text.title` }}>{category}</div>}
+
+          <time className='created'>{date}</time>
+
+          <Styled.h1 as={Heading}>{title}</Styled.h1>
+
+          <div className='article-content'>
+            <MDXRenderer>{mdx.body}</MDXRenderer>
+          </div>
+        </Container>
+      </Flex>
+
+      <Footer />
+    </Layout>
+  )
+}
+
+MediaTemplate.propTypes = {
+  data: PropTypes.shape({
+    mdx: PropTypes.object.isRequired
+  }).isRequired
+}
+
+export const pageQuery = graphql`
+  query($id: String!) {
+    mdx(fields: { id: { eq: $id } }) {
+      body
+      fields {
+        category
+      }
+      frontmatter {
+        banner
+        date(formatString: "MMMM DD, YYYY")
+        description
+        title
+        type
+        soundcloudId
+        youtubeSrc
+      }
+    }
+  }
+`
+
+export default MediaTemplate


### PR DESCRIPTION
This PR adds support for custom media post layouts.

###### SoundCloud

<img width="1687" alt="Screen Shot 2020-09-07 at 11 04 54 PM" src="https://user-images.githubusercontent.com/1934719/92439061-f225ba00-f15e-11ea-85ed-2b0a6052f2f0.png">

###### YouTube

<img width="1687" alt="Screen Shot 2020-09-07 at 11 05 01 PM" src="https://user-images.githubusercontent.com/1934719/92439066-f5b94100-f15e-11ea-9959-2fc3011071b9.png">
