### PR TITLE
refactor: update Goodreads widget to use single endpoint

### DIFF
--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -18,9 +18,7 @@ module.exports = {
       },
       goodreads: {
         username: 'chrisvogt',
-        widgetDataSourceBooks: 'https://recently-read.chrisvogt.me',
-        widgetDataSourceProfile:
-          'https://metrics.chrisvogt.me/api/widgets/goodreads'
+        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads'
       },
       instagram: {
         username: 'c1v0',

--- a/theme/gatsby-config.js
+++ b/theme/gatsby-config.js
@@ -24,8 +24,7 @@ module.exports = () => ({
       },
       goodreads: {
         username: '',
-        widgetDataSourceBooks: '',
-        widgetDataSourceProfile: ''
+        widgetDataSource: ''
       },
       instagram: {
         username: '',

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/home-widgets.js
+++ b/theme/src/components/home-widgets.js
@@ -9,8 +9,7 @@ import Spotify from '../components/widgets/spotify'
 import useSiteMetadata from '../hooks/use-site-metadata'
 import {
   getGithubWidgetDataSource,
-  getGoodreadsWidgetDataSourceBooks,
-  getGoodreadsWidgetDataSourceProfile,
+  getGoodreadsWidgetDataSource,
   getInstagramWidgetDataSource,
   getSpotifyWidgetDataSource
 } from '../selectors/metadata'
@@ -30,8 +29,7 @@ const HomeWidgets = () => {
   const metadata = useSiteMetadata()
 
   const githubDataSource = getGithubWidgetDataSource(metadata)
-  const goodreadsDataSourceBooks = getGoodreadsWidgetDataSourceBooks(metadata)
-  const goodreadsDataSourceProfile = getGoodreadsWidgetDataSourceProfile(metadata)
+  const goodreadsDataSource = getGoodreadsWidgetDataSource(metadata)
   const instagramDataSource = getInstagramWidgetDataSource(metadata)
   const spotifyDataSource = getSpotifyWidgetDataSource(metadata)
 
@@ -41,7 +39,7 @@ const HomeWidgets = () => {
 
       {instagramDataSource && <Instagram />}
       {githubDataSource && <GitHub />}
-      {goodreadsDataSourceBooks && goodreadsDataSourceProfile && <Goodreads />}
+      {goodreadsDataSource && <Goodreads />}
       {spotifyDataSource && <Spotify />}
     </>
   )

--- a/theme/src/components/widgets/goodreads/goodreads-widget.js
+++ b/theme/src/components/widgets/goodreads/goodreads-widget.js
@@ -4,8 +4,7 @@ import { Box, Grid } from '@theme-ui/components'
 
 import {
   getGoodreadsUsername,
-  getGoodreadsWidgetDataSourceBooks,
-  getGoodreadsWidgetDataSourceProfile
+  getGoodreadsWidgetDataSource,
 } from '../../../selectors/metadata'
 
 import useDataSource from '../../../hooks/use-data-source'
@@ -27,15 +26,15 @@ export default () => {
   const metadata = useSiteMetadata()
 
   const goodreadsUsername = getGoodreadsUsername(metadata)
-  const booksDataSource = getGoodreadsWidgetDataSourceBooks(metadata)
-  const profileDataSource = getGoodreadsWidgetDataSourceProfile(metadata)
+  const dataSource = getGoodreadsWidgetDataSource(metadata)
 
-  const { isLoadingBooks, data: booksData } = useDataSource(booksDataSource)
-  const { isLoadingProfile, data: profileData } = useDataSource(
-    profileDataSource
-  )
+  const { isLoading, data } = useDataSource(dataSource)
 
-  const { profile = {}, updates = [] } = profileData
+  const { profile = {}, updates = [], recentlyReadBooks = [] } = data
+
+  const books = recentlyReadBooks.length && recentlyReadBooks
+    .filter(({ thumbnail }) => Boolean(thumbnail))
+    .slice(0, 12)
 
   const status = updates.length && getStatusFromUpdates(updates)
 
@@ -43,7 +42,7 @@ export default () => {
     <CallToAction
       title={`${goodreadsUsername} on Goodreads`}
       url={`https://www.goodreads.com/${goodreadsUsername}`}
-      isLoading={isLoadingBooks || isLoadingProfile}
+      isLoading={isLoading}
     >
       Visit Profile
       <span className='read-more-icon'>&rarr;</span>
@@ -56,13 +55,13 @@ export default () => {
 
       <Grid gap={4} sx={{ gridTemplateColumns: [`auto`, `auto`, `1fr 70%`] }}>
         <Box>
-          <UserProfile isLoading={isLoadingProfile} profile={profile} />
+          <UserProfile isLoading={isLoading} profile={profile} />
         </Box>
         <Box>
-          <RecentlyReadBooks isLoading={isLoadingBooks} books={booksData} />
+          <RecentlyReadBooks isLoading={isLoading} books={books} />
           <UserStatus
             actorName={profile.name}
-            isLoading={isLoadingProfile}
+            isLoading={isLoading}
             status={status}
           />
         </Box>

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -16,7 +16,7 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
     className="instagram-item-image css-nowwr3-InstagramWidgetItem"
     crossOrigin="anonymous"
     height="400"
-    src="undefined?h=400"
+    src="undefined?h=400&fm=webp&auto=format"
   />
 </a>
 `;

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -36,7 +36,7 @@ const InstagramWidgetItem = props => {
       <img
         crossOrigin='anonymous'
         className='instagram-item-image'
-        src={`${cdnMediaURL}?h=400`}
+        src={`${cdnMediaURL}?h=400&fm=webp&auto=format`}
         height='400'
         alt='Instagram post thumbnail'
         sx={{

--- a/theme/src/hooks/use-site-metadata.js
+++ b/theme/src/hooks/use-site-metadata.js
@@ -25,8 +25,7 @@ const useSiteMetadata = () => {
               }
               goodreads {
                 username
-                widgetDataSourceBooks
-                widgetDataSourceProfile
+                widgetDataSource
               }
               instagram {
                 username

--- a/theme/src/selectors/metadata.js
+++ b/theme/src/selectors/metadata.js
@@ -17,11 +17,8 @@ export const getGithubWidgetDataSource = metadata =>
 export const getGoodreadsUsername = metadata =>
   get(metadata, 'widgets.goodreads.username')
 
-export const getGoodreadsWidgetDataSourceBooks = metadata =>
-  get(metadata, 'widgets.goodreads.widgetDataSourceBooks')
-
-export const getGoodreadsWidgetDataSourceProfile = metadata =>
-  get(metadata, 'widgets.goodreads.widgetDataSourceProfile')
+export const getGoodreadsWidgetDataSource = metadata =>
+  get(metadata, 'widgets.goodreads.widgetDataSource')
 
 export const getHeadline = metadata => get(metadata, 'headline')
 

--- a/theme/src/selectors/metadata.spec.js
+++ b/theme/src/selectors/metadata.spec.js
@@ -5,8 +5,7 @@ import {
   getGithubUsername,
   getGithubWidgetDataSource,
   getGoodreadsUsername,
-  getGoodreadsWidgetDataSourceBooks,
-  getGoodreadsWidgetDataSourceProfile,
+  getGoodreadsWidgetDataSource,
   getHeadline,
   getImageURL,
   getInstagramUsername,
@@ -40,8 +39,7 @@ const metadata = {
     },
     goodreads: {
       username: 'private-sphere-theme',
-      widgetDataSourceBooks: 'https://recently-read.chrisvogt.me',
-      widgetDataSourceProfile:
+      widgetDataSource:
         'https://metrics.chrisvogt.me/api/widget-content?widget=goodreads'
     },
     instagram: {
@@ -91,14 +89,9 @@ describe('Metadata Selectors', () => {
     expect(result).toEqual(metadata.widgets.goodreads.username)
   })
 
-  it('selects the goodreads books data source', () => {
-    const result = getGoodreadsWidgetDataSourceBooks(metadata)
-    expect(result).toEqual(metadata.widgets.goodreads.widgetDataSourceBooks)
-  })
-
-  it('selects the goodreads profiles data source', () => {
-    const result = getGoodreadsWidgetDataSourceProfile(metadata)
-    expect(result).toEqual(metadata.widgets.goodreads.widgetDataSourceProfile)
+  it('selects the goodreads widget data source', () => {
+    const result = getGoodreadsWidgetDataSource(metadata)
+    expect(result).toEqual(metadata.widgets.goodreads.widgetDataSource)
   })
 
   it('selects the profiles widget metas data source', () => {


### PR DESCRIPTION
This PR refactors the Goodreads widget to utilize the latest version of my metrics API, which now serves the recently read books data. It also slips in a change for the Instagram widget to ask for webp images when rendering photos.