### PR TITLE
fix: build frozen due to prerelease version and full height

### DIFF
--- a/theme/gatsby-browser.js
+++ b/theme/gatsby-browser.js
@@ -1,2 +1,4 @@
+import './src/styles/global.css'
+
 require('prism-themes/themes/prism-material-light.css')
 require('prismjs/plugins/line-numbers/prism-line-numbers.css')

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.15.0-alpha",
+  "version": "0.15.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/styles/global.css
+++ b/theme/src/styles/global.css
@@ -1,0 +1,11 @@
+html,
+body,
+#___gatsby,
+#gatsby-focus-wrapper {
+  height: 100%;
+}
+
+#gatsby-focus-wrapper {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
This PR closes #64 by pushing the footer to the bottom of the page using flexbox and global styles.

#### Before

<img width="1505" alt="Screen Shot 2020-09-19 at 7 45 21 AM" src="https://user-images.githubusercontent.com/1934719/93672262-5ea59080-fa5e-11ea-95d6-8c01b769dc20.png">

#### After

<img width="1505" alt="Screen Shot 2020-09-19 at 9 39 12 AM" src="https://user-images.githubusercontent.com/1934719/93672265-649b7180-fa5e-11ea-83ec-ddb096dcfde1.png">
