### PR TITLE
fix: revert wrapPageElement to fix page layout issues

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,8 +5,9 @@
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",
+    "clean": "gatsby clean",
     "develop": "gatsby develop",
-    "clean": "gatsby clean"
+    "serve": "gatsby serve"
   },
   "dependencies": {
     "gatsby": "^2.24.57",

--- a/theme/gatsby-browser.js
+++ b/theme/gatsby-browser.js
@@ -2,5 +2,4 @@ import './src/styles/global.css'
 import 'prism-themes/themes/prism-material-light.css'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 
-export { default as wrapPageElement } from './wrapPageElement'
 export { default as wrapRootElement } from './wrapRootElement'

--- a/theme/gatsby-ssr.js
+++ b/theme/gatsby-ssr.js
@@ -1,0 +1,1 @@
+export { default as wrapRootElement } from './wrapRootElement'

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/top-navigation.spec.js.snap
+++ b/theme/src/components/__snapshots__/top-navigation.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TopNavigation matches the snapshot 1`] = `
 <div
-  className="TopNavigation css-1uoha03-TopNavigation"
+  className="css-1uoha03-TopNavigation"
 >
   <div
     className="css-wixpt9-TopNavigation"

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -12,10 +12,10 @@ import TopNavigation from './top-navigation'
  * the default navigation, theme styles, and any important providers. Use shadowing
  * to extend this component and attach additional contexts and providers.
  */
-const Layout = ({ children, custom404, path }) => (
+const Layout = ({ children, hideHeader }) => (
   <Fragment>
     {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
-    {path !== '/' && !custom404 && <TopNavigation />}
+    {!hideHeader && <TopNavigation />}
     {children}
     <Footer />
   </Fragment>

--- a/theme/src/components/top-navigation.js
+++ b/theme/src/components/top-navigation.js
@@ -23,10 +23,9 @@ const TopNavigation = ({ hideBackground }) => {
 
   return (
     <div
-      className='TopNavigation'
       sx={{
         background: hideBackground ? 'none' : `url(${trianglify})`,
-        color: `white`
+        variant: `styles.TopNavigation`
       }}
     >
       <Container
@@ -34,6 +33,7 @@ const TopNavigation = ({ hideBackground }) => {
           display: `flex`,
           alignItems: `center`,
           py: 3
+          // textAlign: [`center`, ``, `left`]
         }}
       >
         <div sx={{ flexGrow: 1 }}>

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -135,6 +135,10 @@ export default {
     textDecoration: `none`
   },
 
+  TopNavigation: {
+    color: `white`
+  },
+
   TrackPreview: {
     img: {
       ...floatOnHover,

--- a/theme/src/pages/404.js
+++ b/theme/src/pages/404.js
@@ -3,6 +3,8 @@ import { Container, Flex, jsx } from 'theme-ui'
 import { Fragment, useRef } from 'react'
 import Lottie from 'lottie-react-web'
 
+import Layout from '../components/layout'
+
 const options = Object.freeze({
   animationData: require('../../assets/astronaout.json'),
   autoplay: true,
@@ -12,7 +14,7 @@ const options = Object.freeze({
 const NotFoundPage = () => {
   const ref = useRef()
   return (
-    <Fragment>
+    <Layout>
       <div></div>
       <Container>
         <div sx={{ textAlign: `center` }}>
@@ -32,7 +34,7 @@ const NotFoundPage = () => {
           </p>
         </div>
       </Container>
-    </Fragment>
+    </Layout>
   )
 }
 

--- a/theme/src/pages/latest.js
+++ b/theme/src/pages/latest.js
@@ -5,13 +5,14 @@ import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 
 import { getPosts } from '../hooks/use-recent-posts'
+import Layout from '../components/layout'
 import PostCard from '../components/widgets/recent-posts/post-card'
 import SEO from '../components/seo'
 
 export default ({ data }) => {
   const posts = getPosts(data)
   return (
-    <Fragment>
+    <Layout>
       <SEO
         title='Latest Content'
         description='A list of the most recent articles published on my blog.'
@@ -50,7 +51,7 @@ export default ({ data }) => {
           </Styled.div>
         </Container>
       </Flex>
-    </Fragment>
+    </Layout>
   )
 }
 

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -6,6 +6,7 @@ import { graphql } from 'gatsby'
 import Header from '../components/header'
 import HomeHeaderContent from '../components/home-header-content'
 import HomeWidgets from '../components/home-widgets'
+import Layout from '../components/layout'
 import SEO from '../components/seo'
 import TopNavigation from '../components/top-navigation'
 
@@ -19,7 +20,7 @@ const HomeTemplate = props => {
   const subhead = getSubhead(siteMetadata)
 
   return (
-    <Fragment>
+    <Layout hideHeader>
       <SEO title='Home' />
 
       <Header showSwoop hideTopPadding>
@@ -41,7 +42,7 @@ const HomeTemplate = props => {
           <HomeWidgets />
         </Container>
       </div>
-    </Fragment>
+    </Layout>
   )
 }
 

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { Container, Flex, jsx, Styled, useThemeUI } from 'theme-ui'
-import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 import { Heading } from '@theme-ui/components'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
@@ -8,6 +7,7 @@ import PropTypes from 'prop-types'
 
 import isDarkMode from '../helpers/isDarkMode'
 
+import Layout from '../components/layout'
 import SEO from '../components/seo'
 
 import SoundCloud from '../shortcodes/soundcloud'
@@ -27,7 +27,7 @@ const MediaTemplate = ({ data }) => {
   const soundcloudId = mdx.frontmatter.soundcloudId
 
   return (
-    <Fragment>
+    <Layout>
       <SEO
         article={true}
         description={description}
@@ -72,7 +72,7 @@ const MediaTemplate = ({ data }) => {
           </div>
         </Container>
       </Flex>
-    </Fragment>
+    </Layout>
   )
 }
 

--- a/theme/src/templates/post.js
+++ b/theme/src/templates/post.js
@@ -1,11 +1,11 @@
 /** @jsx jsx */
 import { Container, Flex, jsx, Styled } from 'theme-ui'
-import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 import { Heading } from '@theme-ui/components'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 import PropTypes from 'prop-types'
 
+import Layout from '../components/layout'
 import SEO from '../components/seo'
 
 const PostTemplate = ({ data }) => {
@@ -18,7 +18,7 @@ const PostTemplate = ({ data }) => {
   const title = mdx.frontmatter.title
 
   return (
-    <Fragment>
+    <Layout>
       <SEO
         article={true}
         description={description}
@@ -45,7 +45,7 @@ const PostTemplate = ({ data }) => {
           </div>
         </Container>
       </Flex>
-    </Fragment>
+    </Layout>
   )
 }
 


### PR DESCRIPTION
I've been running into constant issues with inconsistent rendering since wrapping all pages with the page layout using  `wrapPageElement`. I tried pushing a fix last night, but it didn't help. 😓 

For now, I'm reverting my usage of this element until I understand it better.

![fix-issue](https://user-images.githubusercontent.com/1934719/93901663-9fdeb000-fcab-11ea-8917-71e8393647db.gif)
