### PR TITLE
design: update 404 page to 2-column, full-page style

### DIFF
--- a/theme/assets/astronaut.json
+++ b/theme/assets/astronaut.json
@@ -5,7 +5,7 @@
   "op": 600,
   "w": 1080,
   "h": 1080,
-  "nm": "Astronaout ",
+  "nm": "Astronaut ",
   "ddd": 0,
   "assets": [],
   "layers": [

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/pages/404.js
+++ b/theme/src/pages/404.js
@@ -1,12 +1,12 @@
 /** @jsx jsx */
-import { Container, Flex, jsx } from 'theme-ui'
-import { Fragment, useRef } from 'react'
+import { Box, Container, Flex, Grid, jsx } from 'theme-ui'
+import { useRef } from 'react'
 import Lottie from 'lottie-react-web'
 
 import Layout from '../components/layout'
 
 const options = Object.freeze({
-  animationData: require('../../assets/astronaout.json'),
+  animationData: require('../../assets/astronaut.json'),
   autoplay: true,
   loop: true
 })
@@ -15,25 +15,40 @@ const NotFoundPage = () => {
   const ref = useRef()
   return (
     <Layout>
-      <div></div>
-      <Container>
-        <div sx={{ textAlign: `center` }}>
-          <Lottie
-            key='$floatingAstronaut'
-            ref={ref}
-            height='250px'
-            options={options}
-          />
-          <h1>404</h1>
-          <p>
-            Lost in space? Why not go{' '}
-            <a title='Home page' href='/'>
-              home
-            </a>
-            .
-          </p>
-        </div>
-      </Container>
+      <Flex sx={{ flex: 1 }}>
+        <Container>
+          <Grid
+            gap={4}
+            sx={{ gridTemplateColumns: [`auto`, `auto`, `1fr 70%`] }}
+          >
+            <Box>
+              <Lottie
+                key='$floatingAstronaut'
+                ref={ref}
+                height='50vh'
+                options={options}
+              />
+            </Box>
+            <Box
+              sx={{
+                display: `flex`,
+                flexDirection: `column`,
+                justifyContent: `center`,
+                textAlign: [`center`, `center`, `left`]
+              }}
+            >
+              <h1 sx={{ my: 0 }}>404</h1>
+              <p>
+                Lost in space? Why not go{' '}
+                <a title='Home page' href='/'>
+                  home
+                </a>
+                .
+              </p>
+            </Box>
+          </Grid>
+        </Container>
+      </Flex>
     </Layout>
   )
 }

--- a/theme/src/pages/latest.js
+++ b/theme/src/pages/latest.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { Container, jsx, Styled } from 'theme-ui'
 import { Flex } from '@theme-ui/components'
-import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 
 import { getPosts } from '../hooks/use-recent-posts'

--- a/theme/src/styles/global.css
+++ b/theme/src/styles/global.css
@@ -1,4 +1,7 @@
-html,
+html {
+  min-height: 100%;
+}
+
 body,
 #___gatsby,
 #gatsby-focus-wrapper {

--- a/theme/src/styles/global.css
+++ b/theme/src/styles/global.css
@@ -3,6 +3,7 @@ body,
 #___gatsby,
 #gatsby-focus-wrapper {
   min-height: 100%;
+  height: 100%;
 }
 
 #gatsby-focus-wrapper {

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { Container, jsx } from 'theme-ui'
-import { Fragment } from 'react'
 import { graphql } from 'gatsby'
 
 import Header from '../components/header'


### PR DESCRIPTION
This PR updates the 404 page styles to fill the available height.

### ❯ Screenshots

| Before 	| After 	|
|--------	|-------	|
| ![before](https://user-images.githubusercontent.com/1934719/93975364-35ba1f80-fd2c-11ea-90e4-f2959b7f3c98.gif) | ![ 0cc63df--demo](https://user-images.githubusercontent.com/1934719/93975414-47032c00-fd2c-11ea-98d9-dadb498ab915.gif) |