### PR TITLE
feat: refactor Spotify top tracks to render as either a grid or list

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/profile-metrics-badge.js
+++ b/theme/src/components/widgets/profile-metrics-badge.js
@@ -4,22 +4,17 @@ import PropTypes from 'prop-types'
 
 // import isDarkMode from '../../helpers/isDarkMode'
 
-const ProfileMetricsBadge = ({ isLoading, metrics }) => {
-  // const { colorMode } = useThemeUI()
-  // const variant = isDarkMode(colorMode) ? 'UserProfileDark' : 'UserProfile'
-
-  return (
-    <div sx={{ pb: 4, pt: 1 }}>
-      {(isLoading ? [{}, {}] : metrics).map(
-        ({ displayName, id, value }, idx) => (
-          <Badge key={id || idx} variant='outline' ml={idx !== 0 && 2}>
-            {value} {displayName}
-          </Badge>
-        )
-      )}
-    </div>
-  )
-}
+const ProfileMetricsBadge = ({ isLoading, metrics }) => (
+  <div sx={{ mt: 2, pb: 4, pt: 1, display: `flex`, justifyContent: [`center`, `unset`] }}>
+    {(isLoading ? [{}, {}] : metrics).map(
+      ({ displayName, id, value }, idx) => (
+        <Badge key={id || idx} variant='outline' ml={idx !== 0 && 2}>
+          {value} {displayName}
+        </Badge>
+      )
+    )}
+  </div>
+)
 
 ProfileMetricsBadge.propTypes = {
   /** Sets the component in a loading state when true. */

--- a/theme/src/components/widgets/spotify/top-tracks-grid.js
+++ b/theme/src/components/widgets/spotify/top-tracks-grid.js
@@ -1,0 +1,68 @@
+/** @jsx jsx */
+import { jsx, Styled } from 'theme-ui'
+import Placeholder from 'react-placeholder'
+import { RectShape } from 'react-placeholder/lib/placeholders'
+
+import { floatOnHover } from '../../../gatsby-plugin-theme-ui/abstracts/shadows'
+
+const placeholders = Array(12)
+  .fill()
+  .map((item, idx) => (
+    <div className='show-loading-animation' key={idx}>
+      <RectShape
+        color='#efefef'
+        sx={{
+          borderRadius: `6px`,
+          boxShadow: `md`,
+          paddingBottom: `100%`,
+          width: `100%`
+        }}
+        showLoadingAnimation
+      />
+    </div>
+  ))
+
+
+const TopTracksGrid = ({ isLoading, tracks }) => (
+  <div
+    sx={{
+      display: `grid`,
+      gridGap: [3, 2, 2, 3],
+      gridTemplateColumns: [`repeat(4, 1fr)`, `repeat(6, 1fr)`]
+    }}
+  >
+    <Placeholder ready={!isLoading} customPlaceholder={placeholders}>
+      {tracks.map(track => {
+        const { albumImages = [], id, name, spotifyURL } = track
+        const { url: thumbnailURL } = albumImages.find(
+          image => image.width === 300
+        )
+
+        return (
+          <Styled.a
+            href={spotifyURL}
+            key={id}
+            title={name}
+            sx={{
+            }}
+          >
+            <img
+              alt='album cover'
+              crossOrigin='anonymous'
+              src={thumbnailURL}
+              sx={{
+                ...floatOnHover,
+                boxShadow: `md`,
+                borderRadius: `4px`,
+                objectFit: 'cover',
+                width: '100%'
+              }}
+            />
+          </Styled.a>
+        )
+      })}
+    </Placeholder>
+  </div>
+)
+
+export default TopTracksGrid

--- a/theme/src/components/widgets/spotify/top-tracks-list.js
+++ b/theme/src/components/widgets/spotify/top-tracks-list.js
@@ -1,0 +1,68 @@
+/** @jsx jsx */
+import { jsx, Styled, useThemeUI } from 'theme-ui'
+import isDarkModeHelper from '../../../helpers/isDarkMode'
+
+const TopTracksList = ({ isLoading, tracks = [] }) => {
+  const { colorMode } = useThemeUI()
+  const isDarkMode = isDarkModeHelper(colorMode)
+
+  return (
+    <ul
+      sx={{
+        p: 0,
+        li: {
+          p: 2
+        },
+        'li:nth-child(odd)': {
+          backgroundColor: theme => isDarkMode ? `#252e3c` : theme.colors.gray[2]
+        }
+      }}
+    >
+      {!isLoading &&
+        tracks.map(track => {
+          const { albumImages = [], artists = [], id, name, spotifyURL } = track
+
+          const { url: thumbnailURL } = albumImages.find(
+            image => image.width === 300
+          )
+
+          return (
+            <li key={id} sx={{ listStyle: `none` }}>
+              <Styled.a
+                href={spotifyURL}
+                title={`Listen on Spotify`}
+                sx={{
+                  display: `flex`,
+                  flex: 1
+                }}
+              >
+                <div
+                  sx={{
+                    display: `flex`,
+                    alignItems: `center`,
+                    maxWidth: `45px`
+                  }}
+                >
+                  <img
+                    alt='Song album cover'
+                    crossOrigin='anonymous'
+                    src={thumbnailURL}
+                    sx={{
+                      borderRadius: `4px`,
+                      objectFit: 'cover',
+                      width: '100%'
+                    }}
+                  />
+                </div>
+                <div sx={{ display: `flex`, alignItems: `center`, pl: 2 }}>
+                  {name} by {artists.join(', ')}
+                </div>
+              </Styled.a>
+            </li>
+          )
+        })}
+    </ul>
+  )
+}
+
+export default TopTracksList

--- a/theme/src/components/widgets/spotify/top-tracks.js
+++ b/theme/src/components/widgets/spotify/top-tracks.js
@@ -1,60 +1,51 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, Button } from 'theme-ui'
+import { useState } from 'react'
 import { Heading } from '@theme-ui/components'
-import { RectShape } from 'react-placeholder/lib/placeholders'
-import Placeholder from 'react-placeholder'
 
-import TrackPreview from './track-preview'
+import TopTracksGrid from './top-tracks-grid'
+import TopTracksList from './top-tracks-list'
 
-const placeholders = Array(12)
-  .fill()
-  .map((item, idx) => (
-    <div className='show-loading-animation' key={idx}>
-      <RectShape
-        color='#efefef'
-        sx={{
-          borderRadius: `6px`,
-          boxShadow: `md`,
-          paddingBottom: `100%`,
-          width: `100%`
-        }}
-        showLoadingAnimation
-      />
+const TopTracks = ({ isLoading, tracks = [] }) => {
+  const [renderAsGrid, setRenderAsGrid] = useState(true)
+  const TopTracks = renderAsGrid ? TopTracksGrid : TopTracksList
+
+  return (
+    <div className='gallery'>
+      <div sx={{ display: `flex`, flex: 1, alignItems: `center` }}>
+        <Heading as='h3'>Top Tracks</Heading>
+        <div
+          sx={{
+            display: `flex`,
+            flex: 1,
+            alignItems: `center`,
+            justifyContent: `flex-end`
+          }}
+        >
+          <span sx={{ mr: 2 }}>View as</span>
+          <Button
+            variant={renderAsGrid ? 'disabled' : '3D'}
+            mr={2}
+            onClick={() => setRenderAsGrid(true)}
+            sx={{ py: 0, px: 2 }}
+          >
+            Grid
+          </Button>
+          <Button
+            variant={!renderAsGrid ? 'disabled' : '3D'}
+            onClick={() => setRenderAsGrid(false)}
+            sx={{ py: 0, px: 2 }}
+          >
+            List
+          </Button>
+        </div>
+      </div>
+
+      <p>My 12 most-played tracks over the last 4 weeks.</p>
+
+      <TopTracks isLoading={isLoading} tracks={tracks} />
     </div>
-  ))
-
-const TopTracks = ({ isLoading, tracks = [] }) => (
-  <div className='gallery'>
-    <Heading as='h3'>Top Tracks</Heading>
-
-    <p>My most-played tracks over the last 4 weeks.</p>
-
-    <div
-      sx={{
-        display: `grid`,
-        gridGap: [3, 2, 2, 3],
-        gridTemplateColumns: [`repeat(4, 1fr)`, `repeat(6, 1fr)`]
-      }}
-    >
-      <Placeholder ready={!isLoading} customPlaceholder={placeholders}>
-        {tracks.map(track => {
-          const { albumImages = [], id, name, spotifyURL } = track
-          const { url: thumbnailURL } = albumImages.find(
-            image => image.width === 300
-          )
-
-          return (
-            <TrackPreview
-              key={id}
-              link={spotifyURL}
-              name={name}
-              thumbnailURL={thumbnailURL}
-            />
-          )
-        })}
-      </Placeholder>
-    </div>
-  </div>
-)
+  )
+}
 
 export default TopTracks

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -139,14 +139,6 @@ export default {
     color: `white`
   },
 
-  TrackPreview: {
-    img: {
-      ...floatOnHover,
-      borderRadius: `4px`,
-      boxShadow: `md`
-    }
-  },
-
   VideoWrapper: {
     position: `relative`,
     paddingBottom: `56.25%` /* 16:9 */,


### PR DESCRIPTION
This PR adds a new feature to the Spotify top tracks widget that allows the list of tracks to be rendered as either a Grid or a list.

![manual-test](https://user-images.githubusercontent.com/1934719/100549297-f7a71380-3226-11eb-938e-1f412034444d.gif)
