### PR TITLE
fix: serve webp images only when supported by the browser

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -15,8 +15,8 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
     alt="Instagram post thumbnail"
     className="instagram-item-image css-nowwr3-InstagramWidgetItem"
     crossOrigin="anonymous"
-    height="400"
-    src="undefined?h=400&fm=webp&auto=format"
+    height="280"
+    src="undefined?h=280&auto=format"
   />
 </a>
 `;

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -36,8 +36,8 @@ const InstagramWidgetItem = props => {
       <img
         crossOrigin='anonymous'
         className='instagram-item-image'
-        src={`${cdnMediaURL}?h=400&fm=webp&auto=format`}
-        height='400'
+        src={`${cdnMediaURL}?h=280&auto=format`}
+        height='280'
         alt='Instagram post thumbnail'
         sx={{
           width: '100%',


### PR DESCRIPTION
### ❯ Overview

This PR resolves #78 by allowing the CDN to determine which format to serve.

> If `auto=format` is set and the browser does not support the WebP format, imgix will fall back to the source image type or to any format specified by the fm parameter. – ([Imgix Docs](https://docs.imgix.com/apis/rendering/format/fm))

### ❯ Screenshots

| Before 	| After 	|
|--------	|-------	|
| <img width="1570" alt="Screen Shot 2020-11-29 at 10 58 12 AM" src="https://user-images.githubusercontent.com/1934719/100551134-b8cb8a80-3233-11eb-9c6c-4c1169b2c854.png"> | <img width="1570" alt="Screen Shot 2020-11-29 at 10 58 14 AM" src="https://user-images.githubusercontent.com/1934719/100551136-bb2de480-3233-11eb-8b7b-fcd8bfeb0dab.png"> |
