### PR TITLE
design: refactor to use system fonts instead of web fonts

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/top-navigation.spec.js.snap
+++ b/theme/src/components/__snapshots__/top-navigation.spec.js.snap
@@ -12,7 +12,7 @@ exports[`TopNavigation matches the snapshot 1`] = `
     >
       <a
         aria-current="page"
-        className="css-12gesju-TopNavigation"
+        className="css-76wk06-TopNavigation"
         href="/"
         onClick={[Function]}
         onMouseEnter={[Function]}

--- a/theme/src/components/widgets/__snapshots__/call-to-action.spec.js.snap
+++ b/theme/src/components/widgets/__snapshots__/call-to-action.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CallToAction matches the snapshot 1`] = `
 <a
-  className="css-o1z7o2-CallToAction"
+  className="css-hx6xot-CallToAction"
   title="Example Widget Title"
 >
   Test

--- a/theme/src/components/widgets/call-to-action.js
+++ b/theme/src/components/widgets/call-to-action.js
@@ -29,6 +29,7 @@ const CallToAction = ({ children, isLoading, title, to, url }) => {
       href={url}
       sx={{
         fontSize: 0,
+        fontFamily: 'heading',
         '.read-more-icon': {
           opacity: 0,
           transition: `all .3s ease`

--- a/theme/src/components/widgets/profile-metrics-badge.js
+++ b/theme/src/components/widgets/profile-metrics-badge.js
@@ -2,10 +2,15 @@
 import { Badge, jsx } from 'theme-ui'
 import PropTypes from 'prop-types'
 
-// import isDarkMode from '../../helpers/isDarkMode'
-
 const ProfileMetricsBadge = ({ isLoading, metrics }) => (
-  <div sx={{ mt: 2, pb: 4, pt: 1, display: `flex`, justifyContent: [`center`, `unset`] }}>
+  <div sx={{
+    fontFamily: 'heading',
+    mt: 2,
+    pb: 4,
+    pt: 1,
+    display: `flex`,
+    justifyContent: [`center`, `unset`]
+  }}>
     {(isLoading ? [{}, {}] : metrics).map(
       ({ displayName, id, value }, idx) => (
         <Badge key={id || idx} variant='outline' ml={idx !== 0 && 2}>

--- a/theme/src/gatsby-plugin-theme-ui/abstracts/fonts.js
+++ b/theme/src/gatsby-plugin-theme-ui/abstracts/fonts.js
@@ -1,6 +1,5 @@
 export default {
-  sans:
-    'Open Sans, -apple-system, BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji"',
-  serif: 'PT Serif, Georgia, Cambria, "Times New Roman", Times, serif',
-  mono: 'Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace'
+  sans: '-apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif',
+  serif: 'Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
+  mono: 'Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace'
 }

--- a/theme/src/gatsby-plugin-theme-ui/index.js
+++ b/theme/src/gatsby-plugin-theme-ui/index.js
@@ -97,8 +97,8 @@ export default merge(themePreset, {
   colors,
 
   fonts: {
-    body: fonts.sans,
-    heading: fonts.serif,
+    body: fonts.serif,
+    heading: fonts.sans,
     monospace: fonts.mono
   },
 
@@ -139,6 +139,7 @@ export default merge(themePreset, {
   text: {
     title: {
       color: `primary`,
+      fontFamily: `heading`,
       fontSize: 0,
       fontWeight: `550`,
       textTransform: `uppercase`

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -60,6 +60,9 @@ export default {
   text: {
     inverse: {
       color: `muted`
+    },
+    title: {
+      fontFamily: 'fonts.sans'
     }
   },
 


### PR DESCRIPTION
### ❯ Overview

This PR resolves #75 by removing web fonts altogether in preference of system fonts. I also flip the heading and body fonts so that headings are sans serif and body text uses a serif font.

### ❯ Screenshots

| Before 	| After 	|
|--------	|-------	|
| <img width="1510" alt="Screen Shot 2020-11-29 at 12 35 42 PM" src="https://user-images.githubusercontent.com/1934719/100552968-9f304000-323f-11eb-96ab-4eed5ce4e087.png"> | <img width="1510" alt="Screen Shot 2020-11-29 at 12 35 44 PM" src="https://user-images.githubusercontent.com/1934719/100552967-9d667c80-323f-11eb-8e21-a002ef465607.png"> |
