### PR TITLE
design: 2x the number of Instagram posts shown

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -13,10 +13,11 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
 >
   <img
     alt="Instagram post thumbnail"
-    className="instagram-item-image css-nowwr3-InstagramWidgetItem"
+    className="instagram-item-image css-152q4me-InstagramWidgetItem"
     crossOrigin="anonymous"
     height="280"
-    src="undefined?h=280&auto=format"
+    src="undefined?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format"
+    width="280"
   />
 </a>
 `;

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -36,10 +36,12 @@ const InstagramWidgetItem = props => {
       <img
         crossOrigin='anonymous'
         className='instagram-item-image'
-        src={`${cdnMediaURL}?h=280&auto=format`}
+        src={`${cdnMediaURL}?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format`}
         height='280'
+        width='280'
         alt='Instagram post thumbnail'
         sx={{
+          borderRadius: `4px`,
           width: '100%',
           height: '100%',
           transition: `all 1.5s ease`,

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -17,13 +17,18 @@ import Widget from '../widget'
 import WidgetItem from './instagram-widget-item'
 import WidgetHeader from '../widget-header'
 
-const MAX_IMAGES = 4
+const MAX_IMAGES = 8
 
 const ItemPlaceholder = (
   <div className='image-placeholder'>
     <RectShape
       color='#efefef'
-      sx={{ boxShadow: `md`, width: `100%`, minHeight: `330px` }}
+      sx={{
+        borderRadius: `4px`,
+        boxShadow: `md`,
+        width: `100%`,
+        paddingBottom: `100%`
+      }}
     />
   </div>
 )
@@ -61,14 +66,14 @@ export default () => {
             gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(4, 1fr)']
           }}
         >
-          {(isLoading ? Array(MAX_IMAGES).fill() : posts)
+          {(isLoading ? Array(MAX_IMAGES).fill({}) : posts)
             .slice(0, MAX_IMAGES)
             .map((post, idx) => (
               <ReactPlaceholder
                 customPlaceholder={ItemPlaceholder}
-                showLoadingAnimation
                 key={isLoading ? idx : post.id}
                 ready={!isLoading}
+                showLoadingAnimation
                 type='rect'
               >
                 <WidgetItem post={post} />


### PR DESCRIPTION
### ❯ Overview

This PR:

* Doubles the number of Instagram posts shown in the home page widget.
* Fixes a [Cumulative Layout Shift](https://web.dev/cls/) (CLS) issue identified using Google Lighthouse, caused by the Instagram image skeleton placeholders not matching the real content dimensions or ratio.
* Uses squares and enabled cropping for all Instagram photos.

### ❯ Screenshots

| Before 	| After 	|
|--------	|-------	|
| <img width="1365" alt="Screen Shot 2020-11-29 at 3 23 00 PM" src="https://user-images.githubusercontent.com/1934719/100556402-1d4c1100-3257-11eb-8ebd-1369837bf07f.png"> | <img width="1365" alt="Screen Shot 2020-11-29 at 3 23 06 PM" src="https://user-images.githubusercontent.com/1934719/100556407-1fae6b00-3257-11eb-8d0e-6ab9a9b1ff68.png"> |
