### PR TITLE
refactor: home page navigation and its code style

### DIFF
--- a/theme/src/components/widgets/spotify/top-tracks-list.js
+++ b/theme/src/components/widgets/spotify/top-tracks-list.js
@@ -13,7 +13,7 @@ const TopTracksList = ({ isLoading, tracks = [] }) => {
         li: {
           p: 2
         },
-        'li:nth-child(odd)': {
+        'li:nth-of-type(odd)': {
           backgroundColor: theme => isDarkMode ? `#252e3c` : theme.colors.gray[2]
         }
       }}


### PR DESCRIPTION
This PR...

* Refactors the logic used to determine which navigation links to render. I hope this isn't a frivolous change, but the pattern I used a couple days ago has been eating away at me – it felt messy and hard to read.
* Hides the mobile navigation widget from the home page on mobile.
* Resolves a warning in the browser about using the :nth-child CSS selector.