### PR TITLE
design: polish home navigation and home header styles

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/header.spec.js.snap
+++ b/theme/src/components/__snapshots__/header.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Header matches the snapshot 1`] = `
   className="css-1cr476n-Header"
 >
   <div
-    className="css-1bm78pa-Header"
+    className="css-475vrd-Header"
   >
     Wow!
   </div>

--- a/theme/src/components/__snapshots__/home-header-content.spec.js.snap
+++ b/theme/src/components/__snapshots__/home-header-content.spec.js.snap
@@ -18,11 +18,6 @@ exports[`HomeHeaderContent matches the snapshot 1`] = `
   <div
     className="css-cv27iz-HomeHeaderContent"
   >
-    <h1
-      className="css-ercwh-HomeHeaderContent"
-    >
-      Website Title
-    </h1>
     <p
       className="css-1pntkjx-HomeHeaderContent"
     >

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -22,7 +22,6 @@ const Header = ({ children, hideTopPadding, showSwoop, styles }) => (
     <div
       sx={{
         pt: hideTopPadding ? 0 : 5,
-        pb: 5,
         ...(styles ? styles : {})
       }}
     >

--- a/theme/src/components/home-header-content.js
+++ b/theme/src/components/home-header-content.js
@@ -44,7 +44,7 @@ const HomeHeaderContent = ({ avatar, headline, subhead }) => (
         textAlign: [`center`, ``, `left`]
       }}
     >
-      <Styled.h1 sx={{ mb: 0 }}>{headline}</Styled.h1>
+      {/* <Styled.h1 sx={{ mb: 0, pb: 0 }}>{headline}</Styled.h1> */}
       <Styled.p sx={{ py: 0, my: 0, fontSize: 2 }}>{subhead}</Styled.p>
     </Flex>
   </div>

--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -10,7 +10,7 @@ import {
   getInstagramWidgetDataSource,
   getSpotifyWidgetDataSource
 } from '../selectors/metadata'
-import isDarkMode from '../helpers/isDarkMode'
+import getIsDarkMode from '../helpers/isDarkMode'
 import useSiteMetadata from '../hooks/use-site-metadata'
 
 /**
@@ -77,7 +77,8 @@ const determineLinksToRender = (options = {}) => {
 
 const HomeNavigation = () => {
   const { colorMode } = useThemeUI()
-  const cardStyle = isDarkMode(colorMode) ? 'infoCardDark' : 'infoCard'
+  const isDarkMode = getIsDarkMode(colorMode)
+  const cardStyle = isDarkMode ? 'infoCardDark' : 'infoCard'
   const navItemsRef = useRef()
 
   const metadata = useSiteMetadata()
@@ -135,9 +136,9 @@ const HomeNavigation = () => {
         variant={cardStyle}
       >
         <nav aria-label='Navigate to on-page sections' ref={navItemsRef}>
-          <h3 sx={{ mt: 0, mb: 2 }}>On-page navigation</h3>
+          <h3 sx={{ fontWeight: `unset`, mt: 0, mb: 2 }}>On-page navigation</h3>
           {links.map(({ href, id, text }) => (
-            <Link href={href} key={id} variant='homeNavigation'>
+            <Link href={href} key={id} variant={ isDarkMode ? 'homeNavigationDark' : 'homeNavigation' }>
               {text}
             </Link>
           ))}

--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -135,7 +135,7 @@ const HomeNavigation = () => {
         variant={cardStyle}
       >
         <nav aria-label='Navigate to on-page sections' ref={navItemsRef}>
-          On-page navigation
+          <h3 sx={{ mt: 0, mb: 2 }}>On-page navigation</h3>
           {links.map(({ href, id, text }) => (
             <Link href={href} key={id} variant='homeNavigation'>
               {text}

--- a/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
+++ b/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
@@ -21,7 +21,7 @@ exports[`GitHub Repository Renderer matches the snapshot 1`] = `
       className="css-15n3i4m-Repository"
     >
       Last updated 
-      8 months ago
+      9 months ago
     </span>
     <span>
       View on 

--- a/theme/src/gatsby-plugin-theme-ui/index.js
+++ b/theme/src/gatsby-plugin-theme-ui/index.js
@@ -124,12 +124,16 @@ export default merge(themePreset, {
 
   links: {
     homeNavigation: {
+      color: theme => theme.colors.primary,
       display: `block`,
       width: `100%`,
       py: 2,
       textDecoration: `none`,
       '&:not(:last-of-type)': {
         borderBottom: theme => `1px solid ${theme.colors.gray[3]}`
+      },
+      '&:hover': {
+        backgroundColor: theme => console.log(theme.colors.gray) || theme.colors.gray[1]
       }
     }
   },

--- a/theme/src/gatsby-plugin-theme-ui/index.js
+++ b/theme/src/gatsby-plugin-theme-ui/index.js
@@ -126,14 +126,28 @@ export default merge(themePreset, {
     homeNavigation: {
       color: theme => theme.colors.primary,
       display: `block`,
-      width: `100%`,
       py: 2,
       textDecoration: `none`,
       '&:not(:last-of-type)': {
         borderBottom: theme => `1px solid ${theme.colors.gray[3]}`
       },
       '&:hover': {
-        backgroundColor: theme => console.log(theme.colors.gray) || theme.colors.gray[1]
+        backgroundColor: theme => theme.colors.gray[1]
+      }
+    },
+    homeNavigationDark: {
+      color: theme => theme.colors.gray[8],
+      '&:visited, &:link': {
+        color: 'primary'
+      },
+      display: `block`,
+      py: 2,
+      textDecoration: `none`,
+      '&:not(:last-of-type)': {
+        borderBottom: theme => `1px solid ${theme.colors.gray[8]}`
+      },
+      '&:hover': {
+        backgroundColor: theme => theme.colors.gray[8]
       }
     }
   },


### PR DESCRIPTION
This PR iterates on the home navigation widget's light mode and dark mode styles, giving them a hover state to reflect interaction. It also reduces the height of the home header ever so slightly.

| Before 	| After 	|
|--------	|-------	|
| ![before](https://user-images.githubusercontent.com/1934719/101794368-a6ffa800-3abb-11eb-9498-c6d8dc54ad80.gif) | ![after](https://user-images.githubusercontent.com/1934719/101794391-ac5cf280-3abb-11eb-9d7f-4b1ca235c013.gif) |
