### PR TITLE
fix: add back the home page header element

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/home-header-content.spec.js.snap
+++ b/theme/src/components/__snapshots__/home-header-content.spec.js.snap
@@ -9,7 +9,7 @@ exports[`HomeHeaderContent matches the snapshot 1`] = `
   >
     <img
       alt="Avatar"
-      className="css-4t2e6u-HomeHeaderContent"
+      className="css-18cbw15-HomeHeaderContent"
       height="128"
       src="https://fake-cdn.chrisvogt.me/images/avatar.jpg"
       width="128"
@@ -18,6 +18,11 @@ exports[`HomeHeaderContent matches the snapshot 1`] = `
   <div
     className="css-cv27iz-HomeHeaderContent"
   >
+    <h1
+      className="css-1bfsgft-HomeHeaderContent"
+    >
+      Website Title
+    </h1>
     <p
       className="css-1pntkjx-HomeHeaderContent"
     >

--- a/theme/src/components/home-header-content.js
+++ b/theme/src/components/home-header-content.js
@@ -29,7 +29,7 @@ const HomeHeaderContent = ({ avatar, headline, subhead }) => (
           borderRadius: `50%`,
           borderStyle: `solid`,
           borderWidth: 3,
-          mr: [0, 0, 3]
+          mr: [0, 0, 4]
         }}
         alt='Avatar'
         src={avatar}
@@ -44,7 +44,7 @@ const HomeHeaderContent = ({ avatar, headline, subhead }) => (
         textAlign: [`center`, ``, `left`]
       }}
     >
-      {/* <Styled.h1 sx={{ mb: 0, pb: 0 }}>{headline}</Styled.h1> */}
+      <Styled.h1 sx={{ mb: 0, pb: 0 }}>{headline}</Styled.h1>
       <Styled.p sx={{ py: 0, my: 0, fontSize: 2 }}>{subhead}</Styled.p>
     </Flex>
   </div>


### PR DESCRIPTION
In #86, I accidentally commented out the home page headline text. This PR fixes that.