### PR TITLE
fix: tooltip text color in dark mode

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/tooltip.js
+++ b/theme/src/components/tooltip.js
@@ -1,47 +1,57 @@
-import React from 'react';
+/** @jsx jsx */
+import { Heading, jsx, useThemeUI, Link } from 'theme-ui'
 import TooltipTrigger from 'react-popper-tooltip';
+import getIsDarkMode from '../helpers/isDarkMode'
 import 'react-popper-tooltip/dist/styles.css';
 
-const Tooltip = ({children, tooltip, hideArrow, ...props}) => (
-  <TooltipTrigger
-    {...props}
-    tooltip={({
-      arrowRef,
-      tooltipRef,
-      getArrowProps,
-      getTooltipProps,
-      placement
-    }) => (
-      <div
-        {...getTooltipProps({
-          ref: tooltipRef,
-          className: 'tooltip-container'
-        })}
-      >
-        {!hideArrow && (
-          <div
-            {...getArrowProps({
-              ref: arrowRef,
-              className: 'tooltip-arrow',
-              'data-placement': placement
-            })}
-          />
-        )}
-        {tooltip}
-      </div>
-    )}
-  >
-    {({getTriggerProps, triggerRef}) => (
-      <span
-        {...getTriggerProps({
-          ref: triggerRef,
-          className: 'trigger'
-        })}
-      >
-        {children}
-      </span>
-    )}
-  </TooltipTrigger>
-);
+const Tooltip = ({children, tooltip, hideArrow, ...props}) => {
+  const { colorMode } = useThemeUI()
+  const isDarkMode = getIsDarkMode(colorMode)
+  return (
+    <TooltipTrigger
+      {...props}
+      tooltip={({
+        arrowRef,
+        tooltipRef,
+        getArrowProps,
+        getTooltipProps,
+        placement
+      }) => (
+        <div
+          {...getTooltipProps({
+            ref: tooltipRef,
+            className: 'tooltip-container',
+          })}
+          sx={{
+            border: theme => isDarkMode ? `none` : theme.colors.gray[8],
+            ...(isDarkMode ? { color: `text` } : {})
+          }}
+        >
+          {!hideArrow && (
+            <div
+              {...getArrowProps({
+                ref: arrowRef,
+                className: 'tooltip-arrow',
+                'data-placement': placement
+              })}
+            />
+          )}
+          {tooltip}
+        </div>
+      )}
+    >
+      {({getTriggerProps, triggerRef}) => (
+        <span
+          {...getTriggerProps({
+            ref: triggerRef,
+            className: 'trigger'
+          })}
+        >
+          {children}
+        </span>
+      )}
+    </TooltipTrigger>
+  )
+}
 
-export default Tooltip;
+export default Tooltip


### PR DESCRIPTION
This PR fixes the text color for tooltips in dark mode.

### ❯ Screenshots

| Title 	| Demonstration                                                      	|
|--------	|--------------------------------------------------------------------	|
| Before    	| ![current](https://user-images.githubusercontent.com/1934719/104104244-c117dc00-525b-11eb-802f-b7663fa14bb6.gif) |
| After    	| ![fixed](https://user-images.githubusercontent.com/1934719/104104246-c7a65380-525b-11eb-9906-93b5d27dddcb.gif) |





