### PR TITLE
fix: Goodreads widget tied to GitHub app state

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
+++ b/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
@@ -21,7 +21,7 @@ exports[`GitHub Repository Renderer matches the snapshot 1`] = `
       className="css-15n3i4m-Repository"
     >
       Last updated 
-      10 months ago
+      last year
     </span>
     <span>
       View on 

--- a/theme/src/components/widgets/goodreads/goodreads-widget.js
+++ b/theme/src/components/widgets/goodreads/goodreads-widget.js
@@ -96,8 +96,8 @@ export default () => {
     status
   } = useSelector(state => ({
     books: getBooks(state),
-    hasFatalError: get(state, 'widgets.github.state') === FAILURE,
-    isLoading: get(state, 'widgets.github.state') !== SUCCESS,
+    hasFatalError: get(state, 'widgets.goodreads.state') === FAILURE,
+    isLoading: get(state, 'widgets.goodreads.state') !== SUCCESS,
     metrics: getMetrics(state),
     profileDisplayName: get(state, 'widgets.goodreads.data.profile.name'),
     status: getUserStatus(state)


### PR DESCRIPTION
In #95 I integrated Redux, but accidentally tied the Goodreads widget to the GitHub state. I discovered this after the Goodreads data source stopped syncing and _both_ Goodreads and GitHub went down on my website. :)