### PR TITLE
fix: prevent Instagram images from overflowing outside viewport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,3 @@ jobs:
       - run:
           name: Upload Coverage Report
           command: bash <(curl -s https://codecov.io/bash)
-
-workflows:
-  version: 2
-  build:
-    jobs:
-      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
 
     working_directory: ~/gatsby-theme-private-sphere
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:10
 
     working_directory: ~/gatsby-theme-private-sphere
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,3 +35,9 @@ jobs:
       - run:
           name: Upload Coverage Report
           command: bash <(curl -s https://codecov.io/bash)
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "Personal blog and website with built-in social activity widgets for bloggers, creatives, and developers.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -121,10 +121,32 @@ export default () => {
             {!isLoading && (
               <Carousel
                 currentIndex={currentImage}
+                styles={{
+                  // NOTE(cvogt): these styles were copy + pasted from craigrich/ruff-guide
+                  // as a temporary fix for the `autoSize` feature not working as intended.
+                  container: base => ({
+                    ...base,
+                    height: '100vh'
+                  }),
+                  view: base => ({
+                    ...base,
+                    alignItems: 'center',
+                    display: 'flex ',
+                    height: 'calc(100vh - 54px)',
+                    justifyContent: 'center',
+                    '& > img': {
+                      maxHeight: 'calc(100vh - 94px)'
+                    }
+                  })
+                }}
                 views={media.map(x => ({
                   ...x,
-                  caption: x.caption,
-                  src: `${x.cdnMediaURL}?auto=format`
+                  source: {
+                    download: `${x.cdnMediaURL}?auto=format`,
+                    fullscreen: `${x.cdnMediaURL}?auto=format`,
+                    regular: `${x.cdnMediaURL}?auto=format`,
+                    thumbnail: `${x.cdnMediaURL}?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format`
+                  }
                 }))}
               />
             )}


### PR DESCRIPTION
This PR resolves #101 using custom styles. At first, I tried to use the `autoSize` property made available through `react-images`, but that wasn't behaving as intended: the images weren't properly detecting the size, and were being resized to ~ 3% of the screen space.

This is a temporary solution, since the `react-images` GitHub page now suggests NOT using the package anymore.

### Screenshots

| Before 	| After 	|
|--------	|-------	|
| ![Demo: Before](https://user-images.githubusercontent.com/1934719/112725696-cf7aa900-8ed6-11eb-9f7d-193aa88778f1.gif) | ![Demo: after](https://user-images.githubusercontent.com/1934719/112727501-fdb0b680-8edf-11eb-9d71-ed4099d885ed.gif) |