### PR TITLE
fix: UI accent swoops not matching theme color

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-private-sphere",
   "description": "My personal blog and website, with built-in social activity widgets.",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/header.spec.js.snap
+++ b/theme/src/components/__snapshots__/header.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Header matches the snapshot 1`] = `
     Wow!
   </div>
   <svg
-    className="css-1942e0"
+    className="css-1l6n94m"
     preserveAspectRatio="xMidYMin slice"
     viewBox="0 0 1366 64"
     width="100%"
@@ -18,7 +18,7 @@ exports[`Header matches the snapshot 1`] = `
   >
     <path
       d="M1366,64V3.6c-.2-2.32-88.53-7-218.38.43C1017.88,10.1,846.62,28.18,683,40.89,519.8,54.69,348.92,58,218.94,44.28,89,32.66-.15,4,0,2.48V64Z"
-      fill="var(--theme-ui-colors-background)"
+      fill="inherit"
     />
   </svg>
 </div>

--- a/theme/src/components/footer/footer.js
+++ b/theme/src/components/footer/footer.js
@@ -2,7 +2,7 @@
 import { Container, jsx } from 'theme-ui'
 
 import Profiles from './profiles'
-import SwoopTop from '../artwork/swoop-top'
+import SwoopTop from '../swoops/swoop-top'
 
 import { getFooterText } from '../../selectors/metadata'
 import useSiteMetadata from '../../hooks/use-site-metadata'
@@ -13,7 +13,7 @@ export default () => {
 
   return (
     <div sx={{ variant: `styles.PageFooter` }}>
-      <SwoopTop />
+      <SwoopTop fill='var(--theme-ui-colors-background)' />
       <Container sx={{ textAlign: `center` }}>
         <div sx={{ mb: 3, pt: 3, pb: [4, 5] }}>
           <Profiles />

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -2,7 +2,7 @@
 import { jsx } from 'theme-ui'
 import PropTypes from 'prop-types'
 
-import SwoopBottom from './artwork/swoop-bottom'
+import SwoopBottom from './swoops/swoop-bottom'
 import trianglify from './artwork/trianglify.svg'
 
 /**
@@ -10,26 +10,28 @@ import trianglify from './artwork/trianglify.svg'
  *
  * A decorative masthead element that can be used across page layouts.
  */
-const Header = ({ children, hideTopPadding, showSwoop, styles }) => (
-  <div
-    sx={{
-      variant: `styles.Header`,
-      background: `url(${trianglify})`,
-      backgroundSize: `cover`,
-      backgroundPosition: `bottom center`
-    }}
-  >
+const Header = ({ children, hideTopPadding, showSwoop, styles }) => {
+  return (
     <div
       sx={{
-        pt: hideTopPadding ? 0 : 5,
-        ...(styles ? styles : {})
+        variant: `styles.Header`,
+        background: `url(${trianglify})`,
+        backgroundSize: `cover`,
+        backgroundPosition: `bottom center`
       }}
     >
-      {children}
+      <div
+        sx={{
+          pt: hideTopPadding ? 0 : 5,
+          ...(styles ? styles : {})
+        }}
+      >
+        {children}
+      </div>
+      {showSwoop && <SwoopBottom fill='var(--theme-ui-colors-background)' />}
     </div>
-    {showSwoop && <SwoopBottom invert />}
-  </div>
-)
+  )
+}
 
 Header.propTypes = {
   children: PropTypes.node.isRequired,

--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { Fragment } from 'react'
-import { Heading, jsx, useThemeUI, Link } from 'theme-ui'
+import { Heading, jsx, Link } from 'theme-ui'
 import { useEffect, useRef } from 'react'
 import { Card } from '@theme-ui/components'
 
@@ -76,9 +76,6 @@ const determineLinksToRender = (options = {}) => {
 }
 
 const HomeNavigation = () => {
-  const { colorMode } = useThemeUI()
-  const isDarkMode = getIsDarkMode(colorMode)
-  const cardStyle = isDarkMode ? 'infoCardDark' : 'infoCard'
   const navItemsRef = useRef()
 
   const metadata = useSiteMetadata()
@@ -133,12 +130,12 @@ const HomeNavigation = () => {
           position: `sticky`,
           top: `1.5em`
         }}
-        variant={cardStyle}
+        variant='infoCard'
       >
         <nav aria-label='Navigate to on-page sections' ref={navItemsRef}>
           <h3 sx={{ fontWeight: `unset`, mt: 0, mb: 2 }}>On-page navigation</h3>
           {links.map(({ href, id, text }) => (
-            <Link href={href} key={id} variant={ isDarkMode ? 'homeNavigationDark' : 'homeNavigation' }>
+            <Link href={href} key={id} variant='homeNavigation'>
               {text}
             </Link>
           ))}

--- a/theme/src/components/swoops/__snapshots__/swoop-bottom.spec.js.snap
+++ b/theme/src/components/swoops/__snapshots__/swoop-bottom.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SwoopBottom matches the snapshot 1`] = `
 <svg
-  className="css-1942e0"
+  className="css-1l6n94m"
   preserveAspectRatio="xMidYMin slice"
   viewBox="0 0 1366 64"
   width="100%"
@@ -10,7 +10,7 @@ exports[`SwoopBottom matches the snapshot 1`] = `
 >
   <path
     d="M1366,64V3.6c-.2-2.32-88.53-7-218.38.43C1017.88,10.1,846.62,28.18,683,40.89,519.8,54.69,348.92,58,218.94,44.28,89,32.66-.15,4,0,2.48V64Z"
-    fill="var(--theme-ui-colors-background)"
+    fill="inherit"
   />
 </svg>
 `;

--- a/theme/src/components/swoops/__snapshots__/swoop-top.spec.js.snap
+++ b/theme/src/components/swoops/__snapshots__/swoop-top.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SwoopTop matches the snapshot 1`] = `
 <svg
-  className="css-1qyojn2"
+  className="css-pghdqd"
   preserveAspectRatio="xMidYMax slice"
   viewBox="0 0 1366 64"
   width="100%"
@@ -10,7 +10,7 @@ exports[`SwoopTop matches the snapshot 1`] = `
 >
   <path
     d="M1366,0V60.42c-.2,2.32-88.53,7-218.38-.43-129.74-6.07-301-24.16-464.62-36.87C519.8,9.31,348.92,6,218.94,19.73,89,31.35-.15,60,0,61.54V0Z"
-    fill="var(--theme-ui-colors-background)"
+    fill="inherit"
   />
 </svg>
 `;

--- a/theme/src/components/swoops/get-default-fill-color.js
+++ b/theme/src/components/swoops/get-default-fill-color.js
@@ -1,0 +1,5 @@
+const getDefaultFillColor = ({ colorMode, theme }) => colorMode === 'dark'
+  ? theme.colors.modes.dark.background
+  : theme.colors.background
+
+export default getDefaultFillColor

--- a/theme/src/components/swoops/get-default-fill-color.spec.js
+++ b/theme/src/components/swoops/get-default-fill-color.spec.js
@@ -1,0 +1,32 @@
+import getDefaultFillColor from "./get-default-fill-color"
+
+const mockDarkColor = 'mock-dark-background-color'
+const mockLightColor = 'mock-light-background-color'
+
+const themeFixture = {
+  colors: {
+    background: mockLightColor,
+    modes: {
+      dark: {
+        background: mockDarkColor
+      }
+    }
+  }
+}
+
+describe('getDefaultFillColor', () => {
+  it('selects the dark theme background color when in dark mode', () => {
+    const result = getDefaultFillColor({
+      colorMode: 'dark',
+      theme: themeFixture
+    })
+    expect(result).toEqual(mockDarkColor)
+  })
+
+  it('defaults to the theme background color', () => {
+    const result = getDefaultFillColor({
+      theme: themeFixture
+    })
+    expect(result).toEqual(mockLightColor)
+  })
+})

--- a/theme/src/components/swoops/swoop-bottom.js
+++ b/theme/src/components/swoops/swoop-bottom.js
@@ -1,14 +1,10 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
+import getDefaultFillColor from './get-default-fill-color'
 
 export default ({ fill }) => {
-  const themeContext = useThemeUI()
-  const { colorMode, theme } = themeContext
-
-  const fillColor =
-    colorMode === 'dark'
-      ? theme.colors.modes.dark.background
-      : theme.colors.background
+  const themeUIContext = useThemeUI()
+  const defaultFillColor = getDefaultFillColor(themeUIContext)
 
   return (
     <svg
@@ -17,11 +13,12 @@ export default ({ fill }) => {
       xmlns='http://www.w3.org/2000/svg'
       viewBox='0 0 1366 64'
       sx={{
+        fill: fill || defaultFillColor,
         verticalAlign: 'bottom'
       }}
     >
       <path
-        fill={fill ? fill : fillColor}
+        fill='inherit'
         d='M1366,64V3.6c-.2-2.32-88.53-7-218.38.43C1017.88,10.1,846.62,28.18,683,40.89,519.8,54.69,348.92,58,218.94,44.28,89,32.66-.15,4,0,2.48V64Z'
       ></path>
     </svg>

--- a/theme/src/components/swoops/swoop-bottom.spec.js
+++ b/theme/src/components/swoops/swoop-bottom.spec.js
@@ -14,12 +14,4 @@ describe('SwoopBottom', () => {
     const tree = renderer.create(<WrappedSwoopBottom />).toJSON()
     expect(tree).toMatchSnapshot()
   })
-
-  it('passes the fill prop to the SVG path', () => {
-    const fill = '#ff4600'
-    const testRenderer = renderer.create(<WrappedSwoopBottom fill={fill} />)
-    const testInstance = testRenderer.root
-
-    expect(testInstance.findByType('path').props.fill).toEqual(fill)
-  })
 })

--- a/theme/src/components/swoops/swoop-top.js
+++ b/theme/src/components/swoops/swoop-top.js
@@ -1,14 +1,10 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
+import getDefaultFillColor from './get-default-fill-color'
 
 export default ({ fill }) => {
-  const themeContext = useThemeUI()
-  const { colorMode, theme } = themeContext
-
-  const fillColor =
-    colorMode === 'dark'
-      ? theme.colors.modes.dark.background
-      : theme.colors.background
+  const themeUIContext = useThemeUI()
+  const defaultFillColor = getDefaultFillColor(themeUIContext)
 
   return (
     <svg
@@ -17,11 +13,12 @@ export default ({ fill }) => {
       xmlns='http://www.w3.org/2000/svg'
       viewBox='0 0 1366 64'
       sx={{
+        fill: fill || defaultFillColor,
         verticalAlign: 'top'
       }}
     >
       <path
-        fill={fill ? fill : fillColor}
+        fill='inherit'
         d='M1366,0V60.42c-.2,2.32-88.53,7-218.38-.43-129.74-6.07-301-24.16-464.62-36.87C519.8,9.31,348.92,6,218.94,19.73,89,31.35-.15,60,0,61.54V0Z'
       ></path>
     </svg>

--- a/theme/src/components/swoops/swoop-top.spec.js
+++ b/theme/src/components/swoops/swoop-top.spec.js
@@ -14,12 +14,4 @@ describe('SwoopTop', () => {
     const tree = renderer.create(<WrappedSwoop />).toJSON()
     expect(tree).toMatchSnapshot()
   })
-
-  it('passes the fill prop to the SVG path', () => {
-    const fill = '#ff4600'
-    const testRenderer = renderer.create(<WrappedSwoop fill={fill} />)
-    const testInstance = testRenderer.root
-
-    expect(testInstance.findByType('path').props.fill).toEqual(fill)
-  })
 })

--- a/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
+++ b/theme/src/components/widgets/github/renderers/__snapshots__/repository.spec.js.snap
@@ -21,7 +21,7 @@ exports[`GitHub Repository Renderer matches the snapshot 1`] = `
       className="css-14d26u1-Repository"
     >
       Last updated 
-      last year
+      2 years ago
     </span>
     <span>
       View on 

--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PostCard matches the snapshot 1`] = `
 <a
-  className="css-1u8qly9"
+  className="css-sod6qt"
   href="/blog/article"
   onClick={[Function]}
   onMouseEnter={[Function]}

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -1,17 +1,18 @@
 /** @jsx jsx */
-import { jsx, Themed, useThemeUI } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 import { Card } from '@theme-ui/components'
 import { Link } from 'gatsby'
 
-import isDarkMode from '../../../helpers/isDarkMode'
-
 export default ({ banner, category, date, link, title }) => {
-  const { colorMode } = useThemeUI()
-  const variant = isDarkMode(colorMode) ? 'PostCardDark' : 'PostCard'
-
   return (
-    <Link sx={{ variant: 'styles.PostCardLink' }} to={link}>
-      <Card variant={variant}>
+    <Link
+      sx={{ 
+        color: `var(--theme-ui-colors-panel-text)`,
+        textDecoration: `none`
+      }}
+      to={link}
+    >
+      <Card variant='PostCard'>
         <div
           className='card-content'
           sx={{

--- a/theme/src/gatsby-plugin-theme-ui/abstracts/colors.js
+++ b/theme/src/gatsby-plugin-theme-ui/abstracts/colors.js
@@ -1,9 +1,15 @@
 export default {
   accent: `deeppink`,
   background: `#fcfcfc`,
+  'panel-background': `white`,
+  'panel-divider': theme => `1px solid ${theme.colors.gray[3]}`,
+  'panel-highlight': theme => theme.colors.gray[1],
   modes: {
     dark: {
       background: `#2d3748`,
+      'panel-background': `#252e3c`,
+      'panel-divider': theme => `1px solid ${theme.colors.gray[8]}`,
+      'panel-highlight': theme => theme.colors.gray[8],
       text: `white`
     }
   },

--- a/theme/src/gatsby-plugin-theme-ui/components/card.js
+++ b/theme/src/gatsby-plugin-theme-ui/components/card.js
@@ -2,7 +2,6 @@ import { floatOnHover } from '../abstracts/shadows'
 
 export const card = {
   backgroundColor: `white`,
-  borderBottom: `1px solid white`,
   borderRadius: `3px`,
   boxShadow: `default`,
   color: `text`,
@@ -12,10 +11,9 @@ export const card = {
 }
 
 export const infoCard = {
+  backgroundColor: `var(--theme-ui-colors-panel-background)`,
   boxShadow: `none`,
-  borderBottom: `1px solid #efefef`,
-  borderLeftColor: `text`,
-  borderLeft: `2px solid`,
+  color: 'var(--theme-ui-colors-panel-text)',
   span: {
     fontFamily: `heading`,
     fontWeight: `bold`,
@@ -26,6 +24,8 @@ export const infoCard = {
 export const PostCard = {
   ...card,
   ...floatOnHover,
+  backgroundColor: `var(--theme-ui-colors-panel-background)`,
+  color: 'var(--theme-ui-colors-panel-text)',
   display: `flex`,
   height: `100%`,
   flexDirection: `column`,

--- a/theme/src/gatsby-plugin-theme-ui/index.js
+++ b/theme/src/gatsby-plugin-theme-ui/index.js
@@ -50,18 +50,6 @@ export default merge(themePreset, {
       ...infoCard
     },
 
-    infoCardDark: {
-      ...card,
-      ...infoCard,
-      backgroundColor: `#252e3c`,
-      borderLeft: `3px solid #fefefe`,
-      borderBottom: `none`,
-      color: `white`,
-      a: {
-        color: theme => theme.colors.primary
-      }
-    },
-
     /* The following styles represent specific card components, indicated in PascalCase. */
 
     UserProfile: {
@@ -84,14 +72,7 @@ export default merge(themePreset, {
       backgroundColor: `#1e2530`
     },
 
-    PostCard,
-
-    PostCardDark: {
-      ...PostCard,
-      backgroundColor: `#252e3c`,
-      borderBottom: `none`,
-      color: `white`
-    }
+    PostCard
   },
 
   colors,
@@ -124,30 +105,15 @@ export default merge(themePreset, {
 
   links: {
     homeNavigation: {
-      color: theme => theme.colors.primary,
+      color: 'var(--theme-ui-colors-primary)',
       display: `block`,
       py: 2,
       textDecoration: `none`,
       '&:not(:last-of-type)': {
-        borderBottom: theme => `1px solid ${theme.colors.gray[3]}`
+        borderBottom: 'var(--theme-ui-colors-panel-divider)'
       },
       '&:hover, &:focus': {
-        backgroundColor: theme => theme.colors.gray[1]
-      }
-    },
-    homeNavigationDark: {
-      color: theme => theme.colors.gray[8],
-      '&:visited, &:link': {
-        color: 'primary'
-      },
-      display: `block`,
-      py: 2,
-      textDecoration: `none`,
-      '&:not(:last-of-type)': {
-        borderBottom: theme => `1px solid ${theme.colors.gray[8]}`
-      },
-      '&:hover, &:focus': {
-        backgroundColor: theme => theme.colors.gray[8]
+        backgroundColor: 'var(--theme-ui-colors-panel-highlight)'
       }
     }
   },

--- a/theme/src/gatsby-plugin-theme-ui/styles.js
+++ b/theme/src/gatsby-plugin-theme-ui/styles.js
@@ -138,10 +138,6 @@ export default {
     p: 0
   },
 
-  PostCardLink: {
-    textDecoration: `none`
-  },
-
   TopNavigation: {
     color: `white`
   },

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -38,10 +38,7 @@ const MediaTemplate = ({ data }) => {
       {(youtubeSrc || soundcloudId) && (
         <div
           sx={{
-            backgroundColor: theme =>
-              isDarkMode(colorMode)
-                ? theme.colors.gray[9]
-                : theme.colors.gray[4],
+            backgroundColor: `var(--theme-ui-colors-panel-background)`,
             textAlign: `center`,
             paddingY: 3
           }}


### PR DESCRIPTION
This PR attempts to fix an issue I've seen on the production site where the UI accent swoops don't initially follow the theme colors on initial page load.

### ❯ Demonstration

| Before 	| After 	|
|--------	|-------	|
| <img width="1447" alt="issue" src="https://user-images.githubusercontent.com/1934719/140717508-b9421ccc-4a60-4672-a167-6991ad3d8bed.png"> | <img width="1447" alt="updated" src="https://user-images.githubusercontent.com/1934719/140717526-f2d87ade-3369-4738-bd92-d263bf9914d3.png"> |
